### PR TITLE
core: 文分割ロジック実装（SplitSentences）

### DIFF
--- a/core/document.go
+++ b/core/document.go
@@ -1,0 +1,125 @@
+package core
+
+import (
+	"strings"
+)
+
+// SplitSentences は Document.RawText を文分割ルールに従って []Sentence に分割する。
+//
+// 文分割ルール:
+//  1. 全角区切り文字（。！？」）の直後で分割。区切り文字は直前の文に含める。
+//  2. 半角区切り文字（. ! ?）+ 半角スペースの直後で分割。区切り文字は直前の文に含め、半角スペースは除去。
+//  3. 開き引用符（「）の直前で分割。「は新しい文の先頭になる。
+//  4. 連続改行（空行）は文の区切りとして扱う。
+//  5. 空白のみ・空文字の文はフィルタリングして除外する。
+func (d *Document) SplitSentences() []Sentence {
+	if d.RawText == "" {
+		return nil
+	}
+
+	// まず段落区切り（空行）で分割
+	paragraphs := splitByEmptyLines(d.RawText)
+
+	var rawParts []string
+	for _, para := range paragraphs {
+		parts := splitParagraph(para)
+		rawParts = append(rawParts, parts...)
+	}
+
+	// 空文除外してSentenceスライスを構築
+	var sentences []Sentence
+	for _, part := range rawParts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		sentences = append(sentences, Sentence{
+			Index:   len(sentences),
+			Content: trimmed,
+		})
+	}
+
+	return sentences
+}
+
+// splitByEmptyLines は連続改行（空行）でテキストを分割する。
+func splitByEmptyLines(text string) []string {
+	var result []string
+	var current strings.Builder
+
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			if current.Len() > 0 {
+				result = append(result, current.String())
+				current.Reset()
+			}
+			continue
+		}
+		if current.Len() > 0 && i > 0 && strings.TrimSpace(lines[i-1]) != "" {
+			current.WriteString("\n")
+		}
+		current.WriteString(line)
+	}
+	if current.Len() > 0 {
+		result = append(result, current.String())
+	}
+
+	return result
+}
+
+// splitParagraph は段落内のテキストを文分割ルール1〜3に従って分割する。
+func splitParagraph(text string) []string {
+	runes := []rune(text)
+	var parts []string
+	var current []rune
+
+	i := 0
+	for i < len(runes) {
+		ch := runes[i]
+
+		// ルール3: 開き引用符「の直前で分割
+		if ch == '「' && len(current) > 0 {
+			parts = append(parts, string(current))
+			current = nil
+		}
+
+		current = append(current, ch)
+
+		// ルール1: 全角区切り文字（。！？」）の直後で分割
+		// ただし。！？の直後に」が続く場合は」も同じ文に含める
+		if ch == '。' || ch == '！' || ch == '？' {
+			if i+1 < len(runes) && runes[i+1] == '」' {
+				current = append(current, '」')
+				i++
+			}
+			parts = append(parts, string(current))
+			current = nil
+			i++
+			continue
+		}
+		if ch == '」' {
+			parts = append(parts, string(current))
+			current = nil
+			i++
+			continue
+		}
+
+		// ルール2: 半角区切り文字 + スペースの直後で分割
+		if (ch == '.' || ch == '!' || ch == '?') && i+1 < len(runes) && runes[i+1] == ' ' {
+			parts = append(parts, string(current))
+			current = nil
+			i += 2 // スペースをスキップ
+			continue
+		}
+
+		i++
+	}
+
+	if len(current) > 0 {
+		parts = append(parts, string(current))
+	}
+
+	return parts
+}

--- a/core/document_test.go
+++ b/core/document_test.go
@@ -1,0 +1,168 @@
+package core
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitSentences_EmptyString(t *testing.T) {
+	t.Parallel()
+
+	doc := Document{RawText: ""}
+	got := doc.SplitSentences()
+
+	if len(got) != 0 {
+		t.Errorf("expected empty slice, got %v", got)
+	}
+}
+
+func TestSplitSentences_SingleSentenceWithPeriod(t *testing.T) {
+	t.Parallel()
+
+	doc := Document{RawText: "これはテストです。"}
+	got := doc.SplitSentences()
+
+	want := []Sentence{{Index: 0, Content: "これはテストです。"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestSplitSentences_FullWidthDelimiters(t *testing.T) {
+	t.Parallel()
+
+	doc := Document{RawText: "驚いた！本当に？そうだ。"}
+	got := doc.SplitSentences()
+
+	want := []Sentence{
+		{Index: 0, Content: "驚いた！"},
+		{Index: 1, Content: "本当に？"},
+		{Index: 2, Content: "そうだ。"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestSplitSentences_ClosingQuote(t *testing.T) {
+	t.Parallel()
+
+	doc := Document{RawText: "「はい」そうだ。"}
+	got := doc.SplitSentences()
+
+	want := []Sentence{
+		{Index: 0, Content: "「はい」"},
+		{Index: 1, Content: "そうだ。"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestSplitSentences_HalfWidthDelimiters(t *testing.T) {
+	t.Parallel()
+
+	doc := Document{RawText: "Hello. World! Really? Yes."}
+	got := doc.SplitSentences()
+
+	want := []Sentence{
+		{Index: 0, Content: "Hello."},
+		{Index: 1, Content: "World!"},
+		{Index: 2, Content: "Really?"},
+		{Index: 3, Content: "Yes."},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestSplitSentences_HalfWidthPeriodNoSpace(t *testing.T) {
+	t.Parallel()
+
+	doc := Document{RawText: "値は3.14です。"}
+	got := doc.SplitSentences()
+
+	want := []Sentence{{Index: 0, Content: "値は3.14です。"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestSplitSentences_OpeningQuote(t *testing.T) {
+	t.Parallel()
+
+	doc := Document{RawText: "彼は「はい」と言った。"}
+	got := doc.SplitSentences()
+
+	want := []Sentence{
+		{Index: 0, Content: "彼は"},
+		{Index: 1, Content: "「はい」"},
+		{Index: 2, Content: "と言った。"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestSplitSentences_ParagraphBreak(t *testing.T) {
+	t.Parallel()
+
+	doc := Document{RawText: "第一段落\n\n第二段落"}
+	got := doc.SplitSentences()
+
+	want := []Sentence{
+		{Index: 0, Content: "第一段落"},
+		{Index: 1, Content: "第二段落"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestSplitSentences_EmptySentenceFiltering(t *testing.T) {
+	t.Parallel()
+
+	doc := Document{RawText: "はい。\n\n\n\nいいえ。"}
+	got := doc.SplitSentences()
+
+	want := []Sentence{
+		{Index: 0, Content: "はい。"},
+		{Index: 1, Content: "いいえ。"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestSplitSentences_SpecExample(t *testing.T) {
+	t.Parallel()
+
+	doc := Document{RawText: "彼は「了解。すぐ行く。」と言った。"}
+	got := doc.SplitSentences()
+
+	want := []Sentence{
+		{Index: 0, Content: "彼は"},
+		{Index: 1, Content: "「了解。"},
+		{Index: 2, Content: "すぐ行く。」"},
+		{Index: 3, Content: "と言った。"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestSplitSentences_NestedQuotes(t *testing.T) {
+	t.Parallel()
+
+	doc := Document{RawText: "「彼は「了解」と言った」"}
+	got := doc.SplitSentences()
+
+	want := []Sentence{
+		{Index: 0, Content: "「彼は"},
+		{Index: 1, Content: "「了解」"},
+		{Index: 2, Content: "と言った」"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## 概要

`Document.RawText` を仕様書の文分割ルールに従って `[]Sentence` に分割する `SplitSentences()` 関数を実装する。

Closes #8

## 変更内容

- `core/document.go`: `SplitSentences()` メソッドと内部ヘルパー関数を実装
- `core/document_test.go`: 11テストケースで全ルールをカバー

### 文分割ルール（仕様書 §4 準拠）

| ルール | 説明 |
|---|---|
| 全角区切り文字 | 。！？」の直後で分割、区切り文字は直前の文に含める |
| 半角区切り文字 | `. ` `! ` `? ` の直後で分割、スペース除去 |
| 開き引用符 | 「の直前で分割、「は新しい文の先頭 |
| 段落区切り | 連続改行（空行）で分割 |
| 空文除外 | 空白のみ・空文字の文をフィルタリング |

### キーテストケース

```
入力: 彼は「了解。すぐ行く。」と言った。
期待: ["彼は", "「了解。", "すぐ行く。」", "と言った。"]
```

## テスト計画

- [x] 空文字列 → 空スライス
- [x] 単一文（。で終わる）
- [x] 全角区切り文字（。！？）で複数文分割
- [x] 閉じ引用符」で分割
- [x] 半角区切り文字（`. ` `! ` `? `）で分割、スペース除去
- [x] 半角ピリオド後にスペースなし（`3.14`）→ 分割しない
- [x] 開き引用符「の直前で分割
- [x] 段落区切り（空行）
- [x] 空文除外（連続空行）
- [x] 仕様書の例（`彼は「了解。すぐ行く。」と言った。`）
- [x] ネスト引用符（`「彼は「了解」と言った」`）
- [x] `make lint && make test` pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ドキュメントのテキストを文単位に分割する機能を追加しました。日本語と ASCII の句読点および引用符に対応しています。

* **テスト**
  * 文分割機能の包括的な単体テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->