### PR TITLE
core: 設定ファイル管理（読み込み・バリデーション・マージ）

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -58,6 +59,12 @@ func loadConfigFromPaths(localPath, globalPath string) (*Config, error) {
 	localCfg, localErr := loadConfigFile(localPath)
 	globalCfg, globalErr := loadConfigFile(globalPath)
 
+	if localErr != nil && !errors.Is(localErr, os.ErrNotExist) {
+		return nil, fmt.Errorf("failed to load local config %s: %w", localPath, localErr)
+	}
+	if globalErr != nil && !errors.Is(globalErr, os.ErrNotExist) {
+		return nil, fmt.Errorf("failed to load global config %s: %w", globalPath, globalErr)
+	}
 	if localErr != nil && globalErr != nil {
 		return nil, fmt.Errorf("no config file found: checked %s and %s", localPath, globalPath)
 	}
@@ -127,7 +134,18 @@ func validate(cfg *Config) error {
 }
 
 func mergeConfig(base, override *Config) *Config {
-	merged := *base
+	merged := Config{
+		DefaultProvider: base.DefaultProvider,
+		DefaultPersona:  base.DefaultPersona,
+		Providers:       make(map[string]Provider, len(base.Providers)),
+		Personas:        make(map[string]Persona, len(base.Personas)),
+	}
+	for k, v := range base.Providers {
+		merged.Providers[k] = v
+	}
+	for k, v := range base.Personas {
+		merged.Personas[k] = v
+	}
 
 	if override.DefaultProvider != "" {
 		merged.DefaultProvider = override.DefaultProvider
@@ -136,15 +154,8 @@ func mergeConfig(base, override *Config) *Config {
 		merged.DefaultPersona = override.DefaultPersona
 	}
 
-	if merged.Providers == nil {
-		merged.Providers = make(map[string]Provider)
-	}
 	for k, v := range override.Providers {
 		merged.Providers[k] = v
-	}
-
-	if merged.Personas == nil {
-		merged.Personas = make(map[string]Persona)
 	}
 	for k, v := range override.Personas {
 		merged.Personas[k] = v

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -96,7 +97,8 @@ func TestLoadConfig_ExplicitPath(t *testing.T) {
 }
 
 func TestLoadConfig_ExplicitPathNotFound(t *testing.T) {
-	_, err := LoadConfig("/nonexistent/path/config.json")
+	nonExistentPath := filepath.Join(t.TempDir(), "not-found.json")
+	_, err := LoadConfig(nonExistentPath)
 	if err == nil {
 		t.Fatal("expected error for nonexistent config path")
 	}
@@ -177,6 +179,32 @@ func TestLoadConfig_MergeBothExist(t *testing.T) {
 	// ローカルのproviderも追加される
 	if _, ok := cfg.Providers["local_p"]; !ok {
 		t.Error("local provider should exist after merge")
+	}
+
+	// グローバルのpersonaも残る
+	if _, ok := cfg.Personas["global_persona"]; !ok {
+		t.Error("global persona should still exist after merge")
+	}
+	// ローカルのpersonaも追加される
+	if _, ok := cfg.Personas["local_persona"]; !ok {
+		t.Error("local persona should exist after merge")
+	}
+}
+
+func TestLoadConfig_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	invalidPath := filepath.Join(dir, "yomite.json")
+	if err := os.WriteFile(invalidPath, []byte("{invalid json}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := loadConfigFromPaths(invalidPath, filepath.Join(dir, "nonexistent.json"))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON config")
+	}
+	// エラーメッセージがJSONパースエラーであること（"no config file found"ではない）
+	if got := err.Error(); !strings.Contains(got, "failed to load local config") {
+		t.Errorf("expected local config error, got: %s", got)
 	}
 }
 


### PR DESCRIPTION
## 概要

JSON形式の設定ファイル（`yomite.json` / `config.json`）の読み込み、マージ、バリデーションを実装する。

Closes #9

## 変更内容

- `core/config.go`: Config, Provider, Persona 構造体と LoadConfig() を実装
- `core/config_test.go`: 9テストケースで全要件をカバー

### 設定構造体

| 構造体 | 説明 |
|--------|------|
| `Config` | default_provider, default_persona, providers, personas を保持 |
| `Provider` | type, model, origin（デフォルト: `http://localhost:11434`） |
| `Persona` | display_name, system_prompt, memory_capacity, max_steps |

### 設定ファイル探索ルール

1. `./yomite.json` — 優先（プロジェクト固有）
2. `~/.config/yomite/config.json` — フォールバック（グローバル）
3. 両方存在 → グローバルをベースにローカルで上書き（マージ）
4. どちらも存在しない → エラー
5. 明示パス指定（`--config` 用）にも対応

### バリデーション

- `default_provider` が `providers` に存在すること
- `default_persona` が `personas` に存在すること

## テスト計画

- [x] Config構造体のJSONラウンドトリップ
- [x] 明示パス指定で読み込み + Origin デフォルト値
- [x] 明示パスが存在しない場合エラー
- [x] ローカルファイルのみ → 読み込み成功
- [x] グローバルファイルのみ → 読み込み成功
- [x] 両方存在 → マージ（グローバルベース + ローカル上書き）
- [x] どちらも存在しない → エラー
- [x] default_provider バリデーションエラー
- [x] default_persona バリデーションエラー
- [x] `make lint && make test` pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 設定管理機能を追加しました。ローカルまたはグローバルのJSON設定を読み込み、プロバイダーとペルソナをカスタマイズできます。
  * 指定がない場合の既定値が自動で適用されます。

* **Bug Fixes**
  * 設定参照の整合性を検証し、不整合な既定設定で読み込みが失敗するようになりました。

* **Tests**
  * 設定の読み込み・マージ・検証を網羅する自動テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->