### PR TITLE
fix: Claude Codeのインストール方法をinstall.shに変更

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,5 +13,3 @@ RUN mkdir -p /workspaces && chown vscode:vscode /workspaces
 USER vscode
 
 RUN mkdir -p ${CLAUDE_CONFIG_DIR} && chmod 700 ${CLAUDE_CONFIG_DIR}
-
-RUN npm install -g @anthropic-ai/claude-code

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# tmux設定のリンク
 ln -sf "${SCRIPT_DIR}/.tmux.conf" "${HOME}/.tmux.conf"
+
+curl -fsSL https://claude.ai/install.sh | bash
 
 # .envテンプレートのコピー
 if [ ! -f "${SCRIPT_DIR}/.env" ]; then


### PR DESCRIPTION
## Summary
- Dockerfileからnpm installによるClaude Codeインストールを削除
- post-create.shで公式install.shを使用するインストール方法に変更

## Test plan
- [ ] devcontainerの再ビルドでClaude Codeが正常にインストールされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 開発環境のセットアップを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->