### PR TITLE
fix: watch-queued-issues.sh の廃止フラグを修正

### DIFF
--- a/.claude/scripts/watch-queued-issues.sh
+++ b/.claude/scripts/watch-queued-issues.sh
@@ -19,7 +19,7 @@ echo "Watching for queued issues in ${REPO}..."
 while true; do
   # assign-to-claudeラベル付きかつin-progress-by-claude未付与のIssueを検索
   ISSUE=$(gh issue list --repo "$REPO" --label "assign-to-claude" --state open \
-    --json number,title,labels --sort created --order asc \
+    --search "sort:created-asc" --json number,title,labels \
     -q '[.[] | select(.labels | map(.name) | contains(["in-progress-by-claude"]) | not)] | first // empty')
 
   if [ -n "$ISSUE" ]; then


### PR DESCRIPTION
## Summary
- `gh issue list` の `--sort`/`--order` フラグが現行の gh (v2.89.0) でサポートされていないため、`--search "sort:created-asc"` に置き換え
- これにより `watch-queued-issues.sh` 実行時の `unknown flag: --sort` エラーを解消

## Test plan
- [ ] `watch-queued-issues.sh` を実行し、エラーなくIssue検索が動作することを確認
- [ ] `assign-to-claude` ラベル付きIssueが作成順で正しく取得されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * 内部スクリプトの最適化を実施しました。これはサービスの機能には影響しません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->