### PR TITLE
feat: devcontainerをdocker-compose構成に変更し、Ollamaコンテナを追加

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -1,0 +1,28 @@
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env
+    volumes:
+      - ../..:/workspaces:cached
+    command: sleep infinity
+    depends_on:
+      ollama:
+        condition: service_healthy
+
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:11434/api/tags"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  ollama-data:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,9 @@
 {
   "name": "Ubuntu",
-  "build": {
-    "dockerfile": "Dockerfile"
-  },
+  "dockerComposeFile": "compose.yml",
+  "service": "dev",
+  "runServices": ["ollama"],
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/go:1": {},
@@ -33,10 +34,6 @@
     "WORKSPACE_DIR": "${containerWorkspaceFolder}"
   },
   "initializeCommand": "test -f .devcontainer/.env || cp .devcontainer/.env-template .devcontainer/.env",
-  "runArgs": [
-    "--env-file",
-    ".devcontainer/.env"
-  ],
   "postCreateCommand": "bash .devcontainer/post-create.sh",
   "waitFor": "postCreateCommand"
 }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -14,3 +14,8 @@ if [ ! -f "${SCRIPT_DIR}/.env" ]; then
     echo ".env file created from template."
   fi
 fi
+
+# ollamaにモデルをpull（未ダウンロードの場合のみ実行される）
+echo "Pulling qwen3:1.7b model from Ollama..."
+curl -s http://ollama:11434/api/pull -d '{"name": "qwen3:1.7b"}'
+echo "Ollama model pull completed."


### PR DESCRIPTION
## Summary

- devcontainerを単一コンテナ構成からdocker-compose構成に移行
- `ollama/ollama` イメージを使ったサイドカーコンテナを追加
- healthcheck + `depends_on` でOllama起動後にdevコンテナが立ち上がる構成
- `postCreateCommand` で `qwen3:1.7b` モデルを事前ダウンロード
- `ollama-data` ボリュームでモデルデータを永続化

Closes #34

## Test plan

- [ ] devcontainerのリビルドが正常に完了すること
- [ ] Ollamaコンテナが起動し、ヘルスチェックが通ること
- [ ] `curl http://ollama:11434/api/tags` でqwen3:1.7bモデルが確認できること
- [ ] コンテナ再作成時にモデルの再ダウンロードが不要であること

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発環境設定を改善し、Docker Composeを使用したマルチサービス構成を実装しました。これにより開発環境の管理がより効率的になります。
  * 開発環境のセットアップ時に、AIモデルサービスが自動的に初期化されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->