### PR TITLE
feat: 汎用ログ機構の追加（LLMデバッグログ含む）

### DIFF
--- a/cmd/yomite/run.go
+++ b/cmd/yomite/run.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 
 	"github.com/canpok1/yomite/core"
@@ -62,6 +63,26 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 		return 1
 	}
 
+	// ログファイルを開く
+	logFile, err := os.OpenFile(cfg.Log.Path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "エラー: ログファイルを開けませんでした: %v\n", err)
+		return 1
+	}
+	defer func() { _ = logFile.Close() }()
+
+	handler := slog.NewJSONHandler(logFile, &slog.HandlerOptions{
+		Level: core.ToSlogLevel(cfg.Log.Level),
+	})
+	logger := slog.New(handler)
+
+	logger.Info("config loaded",
+		"log_level", cfg.Log.Level,
+		"log_path", cfg.Log.Path,
+		"provider", providerID,
+		"persona", personaID,
+	)
+
 	if providerID == "" {
 		providerID = cfg.DefaultProvider
 	}
@@ -94,9 +115,9 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 	doc.Sentences = doc.SplitSentences()
 
-	provider := providerFactory(providerCfg)
+	provider := core.NewLoggingProvider(providerFactory(providerCfg), logger)
 
-	steps, err := core.RunSimulation(doc, persona, provider)
+	steps, err := core.RunSimulation(doc, persona, provider, logger)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "エラー: シミュレーション実行に失敗しました: %v\n", err)
 		return 1

--- a/cmd/yomite/run_test.go
+++ b/cmd/yomite/run_test.go
@@ -33,7 +33,9 @@ func intPtr(v int) *int {
 // writeTestConfig は一時ディレクトリにテスト用設定ファイルを作成する。
 func writeTestConfig(t *testing.T) string {
 	t.Helper()
+	logPath := filepath.Join(t.TempDir(), "test.log")
 	cfg := core.Config{
+		Log:             core.LogConfig{Level: "warn", Path: logPath},
 		DefaultProvider: "test-provider",
 		DefaultPersona:  "test-persona",
 		Providers: map[string]core.ProviderConfig{
@@ -347,5 +349,113 @@ func TestOutputText_Reread(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "再読") {
 		t.Errorf("expected reread direction, got: %s", stdout.String())
+	}
+}
+
+func TestRun_Integration_LogFileCreated(t *testing.T) {
+	inputPath := writeTestInput(t, "テスト文1。テスト文2。")
+	logPath := filepath.Join(t.TempDir(), "test.log")
+	cfg := core.Config{
+		Log:             core.LogConfig{Level: "info", Path: logPath},
+		DefaultProvider: "test-provider",
+		DefaultPersona:  "test-persona",
+		Providers: map[string]core.ProviderConfig{
+			"test-provider": {Type: "ollama", Model: "test", Origin: "http://localhost:11434"},
+		},
+		Personas: map[string]core.Persona{
+			"test-persona": {DisplayName: "T", SystemPrompt: "テスト用", MemoryCapacity: 100, MaxSteps: 10},
+		},
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockProvider{
+		responses: []core.SimulationResponse{
+			{CurrentIndex: 0, NextIndex: intPtr(1), Memory: "m1"},
+			{CurrentIndex: 1, NextIndex: nil, Memory: "m2"},
+		},
+	}
+
+	origFactory := providerFactory
+	providerFactory = func(_ core.ProviderConfig) core.Provider { return mock }
+	defer func() { providerFactory = origFactory }()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"-f", inputPath, "--config", configPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d; stderr: %s", code, stderr.String())
+	}
+
+	// ログファイルが作成されていること
+	logData, err := os.ReadFile(cfg.Log.Path)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+	logContent := string(logData)
+
+	if !strings.Contains(logContent, "simulation started") {
+		t.Errorf("expected 'simulation started' in log file")
+	}
+	if !strings.Contains(logContent, "simulation finished") {
+		t.Errorf("expected 'simulation finished' in log file")
+	}
+}
+
+func TestRun_Integration_DebugLogIncludesLLM(t *testing.T) {
+	inputPath := writeTestInput(t, "テスト文。")
+	logPath := filepath.Join(t.TempDir(), "debug.log")
+	cfg := core.Config{
+		Log:             core.LogConfig{Level: "debug", Path: logPath},
+		DefaultProvider: "test-provider",
+		DefaultPersona:  "test-persona",
+		Providers: map[string]core.ProviderConfig{
+			"test-provider": {Type: "ollama", Model: "test", Origin: "http://localhost:11434"},
+		},
+		Personas: map[string]core.Persona{
+			"test-persona": {DisplayName: "T", SystemPrompt: "テスト用", MemoryCapacity: 100, MaxSteps: 10},
+		},
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(configPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockProvider{
+		responses: []core.SimulationResponse{
+			{CurrentIndex: 0, NextIndex: nil, Memory: "m", RawResponseText: `{"current_index":0}`},
+		},
+	}
+
+	origFactory := providerFactory
+	providerFactory = func(_ core.ProviderConfig) core.Provider { return mock }
+	defer func() { providerFactory = origFactory }()
+
+	var stdout, stderr bytes.Buffer
+	code := Run([]string{"-f", inputPath, "--config", configPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d; stderr: %s", code, stderr.String())
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+	logContent := string(logData)
+
+	if !strings.Contains(logContent, "llm request") {
+		t.Errorf("expected 'llm request' in debug log")
+	}
+	if !strings.Contains(logContent, "llm response") {
+		t.Errorf("expected 'llm response' in debug log")
 	}
 }

--- a/core/config.go
+++ b/core/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 )
@@ -12,10 +13,17 @@ const defaultOrigin = "http://localhost:11434"
 
 // Config はアプリケーション全体の設定を保持する。
 type Config struct {
+	Log             LogConfig                 `json:"log"`
 	DefaultProvider string                    `json:"default_provider"`
 	DefaultPersona  string                    `json:"default_persona"`
 	Providers       map[string]ProviderConfig `json:"providers"`
 	Personas        map[string]Persona        `json:"personas"`
+}
+
+// LogConfig はログ出力の設定を保持する。
+type LogConfig struct {
+	Level string `json:"level"` // "debug", "info", "warn"
+	Path  string `json:"path"`  // ログ出力先ファイルパス
 }
 
 // ProviderConfig はLLMプロバイダの接続情報を表す。
@@ -120,6 +128,16 @@ func applyDefaults(cfg *Config) {
 }
 
 func validate(cfg *Config) error {
+	if cfg.Log.Path == "" {
+		return fmt.Errorf("log.path is required")
+	}
+	switch cfg.Log.Level {
+	case "debug", "info", "warn":
+		// valid
+	default:
+		return fmt.Errorf("log.level must be one of: debug, info, warn (got %q)", cfg.Log.Level)
+	}
+
 	if cfg.DefaultProvider != "" {
 		if _, ok := cfg.Providers[cfg.DefaultProvider]; !ok {
 			return fmt.Errorf("default_provider %q not found in providers", cfg.DefaultProvider)
@@ -133,8 +151,23 @@ func validate(cfg *Config) error {
 	return nil
 }
 
+// ToSlogLevel は設定ファイルのログレベル文字列を slog.Level に変換する。
+func ToSlogLevel(level string) slog.Level {
+	switch level {
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn":
+		return slog.LevelWarn
+	default:
+		return slog.LevelWarn
+	}
+}
+
 func mergeConfig(base, override *Config) *Config {
 	merged := Config{
+		Log:             base.Log,
 		DefaultProvider: base.DefaultProvider,
 		DefaultPersona:  base.DefaultPersona,
 		Providers:       make(map[string]ProviderConfig, len(base.Providers)),
@@ -147,6 +180,9 @@ func mergeConfig(base, override *Config) *Config {
 		merged.Personas[k] = v
 	}
 
+	if override.Log.Path != "" {
+		merged.Log = override.Log
+	}
 	if override.DefaultProvider != "" {
 		merged.DefaultProvider = override.DefaultProvider
 	}

--- a/core/config_test.go
+++ b/core/config_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"encoding/json"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,7 @@ import (
 
 func TestConfigJSONRoundTrip(t *testing.T) {
 	original := Config{
+		Log:             LogConfig{Level: "info", Path: "/tmp/test.log"},
 		DefaultProvider: "local_ollama",
 		DefaultPersona:  "beginner",
 		Providers: map[string]ProviderConfig{
@@ -39,6 +41,12 @@ func TestConfigJSONRoundTrip(t *testing.T) {
 		t.Fatalf("Unmarshal failed: %v", err)
 	}
 
+	if restored.Log.Level != original.Log.Level {
+		t.Errorf("Log.Level: got %q, want %q", restored.Log.Level, original.Log.Level)
+	}
+	if restored.Log.Path != original.Log.Path {
+		t.Errorf("Log.Path: got %q, want %q", restored.Log.Path, original.Log.Path)
+	}
 	if restored.DefaultProvider != original.DefaultProvider {
 		t.Errorf("DefaultProvider: got %q, want %q", restored.DefaultProvider, original.DefaultProvider)
 	}
@@ -67,6 +75,7 @@ func TestLoadConfig_ExplicitPath(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.json")
 	content := `{
+		"log": {"level": "warn", "path": "/tmp/test.log"},
 		"default_provider": "local",
 		"default_persona": "test",
 		"providers": {
@@ -249,10 +258,137 @@ func TestValidate_InvalidDefaultPersona(t *testing.T) {
 	}
 }
 
+func TestValidate_LogPathRequired(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	content := `{
+		"log": {"level": "warn"},
+		"default_provider": "local",
+		"default_persona": "test",
+		"providers": {"local": {"type": "ollama", "model": "gemma2"}},
+		"personas": {"test": {"display_name": "T", "system_prompt": "t", "memory_capacity": 100, "max_steps": 10}}
+	}`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(configPath)
+	if err == nil {
+		t.Fatal("expected validation error for missing log.path")
+	}
+	if !strings.Contains(err.Error(), "log.path is required") {
+		t.Errorf("expected log.path error, got: %s", err.Error())
+	}
+}
+
+func TestValidate_LogLevelInvalid(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	content := `{
+		"log": {"level": "trace", "path": "/tmp/test.log"},
+		"default_provider": "local",
+		"default_persona": "test",
+		"providers": {"local": {"type": "ollama", "model": "gemma2"}},
+		"personas": {"test": {"display_name": "T", "system_prompt": "t", "memory_capacity": 100, "max_steps": 10}}
+	}`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(configPath)
+	if err == nil {
+		t.Fatal("expected validation error for invalid log.level")
+	}
+	if !strings.Contains(err.Error(), "log.level must be one of") {
+		t.Errorf("expected log.level error, got: %s", err.Error())
+	}
+}
+
+func TestValidate_LogMissing(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+	content := `{
+		"default_provider": "local",
+		"default_persona": "test",
+		"providers": {"local": {"type": "ollama", "model": "gemma2"}},
+		"personas": {"test": {"display_name": "T", "system_prompt": "t", "memory_capacity": 100, "max_steps": 10}}
+	}`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(configPath)
+	if err == nil {
+		t.Fatal("expected validation error for missing log field")
+	}
+}
+
+func TestMergeConfig_LogLocalOverride(t *testing.T) {
+	base := &Config{
+		Log:             LogConfig{Level: "warn", Path: "/tmp/global.log"},
+		DefaultProvider: "global_p",
+		Providers:       map[string]ProviderConfig{"global_p": {Type: "ollama", Model: "gemma2"}},
+		Personas:        map[string]Persona{},
+	}
+	override := &Config{
+		Log:       LogConfig{Level: "debug", Path: "/tmp/local.log"},
+		Providers: map[string]ProviderConfig{},
+		Personas:  map[string]Persona{},
+	}
+
+	merged := mergeConfig(base, override)
+	if merged.Log.Level != "debug" {
+		t.Errorf("Log.Level: got %q, want %q", merged.Log.Level, "debug")
+	}
+	if merged.Log.Path != "/tmp/local.log" {
+		t.Errorf("Log.Path: got %q, want %q", merged.Log.Path, "/tmp/local.log")
+	}
+}
+
+func TestMergeConfig_LogBaseOnly(t *testing.T) {
+	base := &Config{
+		Log:       LogConfig{Level: "info", Path: "/tmp/global.log"},
+		Providers: map[string]ProviderConfig{},
+		Personas:  map[string]Persona{},
+	}
+	override := &Config{
+		Providers: map[string]ProviderConfig{},
+		Personas:  map[string]Persona{},
+	}
+
+	merged := mergeConfig(base, override)
+	if merged.Log.Level != "info" {
+		t.Errorf("Log.Level: got %q, want %q", merged.Log.Level, "info")
+	}
+	if merged.Log.Path != "/tmp/global.log" {
+		t.Errorf("Log.Path: got %q, want %q", merged.Log.Path, "/tmp/global.log")
+	}
+}
+
+func TestToSlogLevel(t *testing.T) {
+	tests := []struct {
+		input string
+		want  slog.Level
+	}{
+		{"debug", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+		{"warn", slog.LevelWarn},
+		{"unknown", slog.LevelWarn},
+		{"", slog.LevelWarn},
+	}
+	for _, tt := range tests {
+		got := ToSlogLevel(tt.input)
+		if got != tt.want {
+			t.Errorf("ToSlogLevel(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
 // writeTestConfig はテスト用の設定ファイルを書き出すヘルパー。
 func writeTestConfig(t *testing.T, path, defaultProvider, defaultPersona string, providers map[string]ProviderConfig, personas map[string]Persona) {
 	t.Helper()
 	cfg := Config{
+		Log:             LogConfig{Level: "warn", Path: "/tmp/test.log"},
 		DefaultProvider: defaultProvider,
 		DefaultPersona:  defaultPersona,
 		Providers:       providers,

--- a/core/logging_provider.go
+++ b/core/logging_provider.go
@@ -1,0 +1,56 @@
+package core
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// LoggingProvider は Provider をラップし、LLMリクエスト/レスポンスをログに記録するデコレータ。
+type LoggingProvider struct {
+	inner  Provider
+	logger *slog.Logger
+}
+
+// NewLoggingProvider は LoggingProvider を生成する。
+func NewLoggingProvider(inner Provider, logger *slog.Logger) *LoggingProvider {
+	return &LoggingProvider{inner: inner, logger: logger}
+}
+
+// Execute は内部プロバイダの Execute を呼び出し、リクエストとレスポンスをログに記録する。
+func (p *LoggingProvider) Execute(req SimulationRequest) (SimulationResponse, error) {
+	debugEnabled := p.logger.Enabled(context.Background(), slog.LevelDebug)
+
+	if debugEnabled {
+		system, user := BuildPrompt(req)
+		p.logger.Debug("llm request",
+			"current_index", req.CurrentIndex,
+			"total_sentences", req.TotalSentences,
+			"system_prompt", system,
+			"user_prompt", user,
+		)
+	}
+
+	start := time.Now()
+	resp, err := p.inner.Execute(req)
+	durationMs := time.Since(start).Milliseconds()
+
+	if err != nil {
+		p.logger.Warn("llm error",
+			"current_index", req.CurrentIndex,
+			"error", err.Error(),
+			"duration_ms", durationMs,
+		)
+		return resp, err
+	}
+
+	if debugEnabled {
+		p.logger.Debug("llm response",
+			"current_index", req.CurrentIndex,
+			"raw_response", resp.RawResponseText,
+			"duration_ms", durationMs,
+		)
+	}
+
+	return resp, nil
+}

--- a/core/logging_provider_test.go
+++ b/core/logging_provider_test.go
@@ -1,0 +1,160 @@
+package core
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestLoggingProvider_LogsRequestAndResponse(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	inner := &mockProvider{
+		responses: []SimulationResponse{
+			{CurrentIndex: 0, NextIndex: intPtr(1), Memory: "memo", RawResponseText: `{"current_index":0,"next_index":1,"memory":"memo"}`},
+		},
+	}
+
+	lp := NewLoggingProvider(inner, logger)
+	req := SimulationRequest{
+		SystemPrompt:    "テスト用",
+		CurrentSentence: "文1。",
+		CurrentIndex:    0,
+		TotalSentences:  2,
+		Memory:          "",
+	}
+
+	resp, err := lp.Execute(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.CurrentIndex != 0 {
+		t.Errorf("CurrentIndex: got %d, want 0", resp.CurrentIndex)
+	}
+
+	logs := buf.String()
+	if !strings.Contains(logs, "llm request") {
+		t.Errorf("expected 'llm request' log entry, got: %s", logs)
+	}
+	if !strings.Contains(logs, "llm response") {
+		t.Errorf("expected 'llm response' log entry, got: %s", logs)
+	}
+	if !strings.Contains(logs, "duration_ms") {
+		t.Errorf("expected 'duration_ms' in log, got: %s", logs)
+	}
+}
+
+func TestLoggingProvider_LogsOnError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	inner := &mockProvider{
+		errors: []error{errors.New("connection failed")},
+	}
+
+	lp := NewLoggingProvider(inner, logger)
+	req := SimulationRequest{
+		SystemPrompt:    "テスト用",
+		CurrentSentence: "文1。",
+		CurrentIndex:    0,
+		TotalSentences:  1,
+	}
+
+	_, err := lp.Execute(req)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	logs := buf.String()
+	if !strings.Contains(logs, "llm request") {
+		t.Errorf("expected 'llm request' log entry even on error")
+	}
+	if !strings.Contains(logs, "llm error") {
+		t.Errorf("expected 'llm error' log entry, got: %s", logs)
+	}
+}
+
+func TestLoggingProvider_NoLogAtInfoLevel(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	inner := &mockProvider{
+		responses: []SimulationResponse{
+			{CurrentIndex: 0, NextIndex: nil, Memory: "m"},
+		},
+	}
+
+	lp := NewLoggingProvider(inner, logger)
+	req := SimulationRequest{
+		SystemPrompt:    "テスト用",
+		CurrentSentence: "文1。",
+		CurrentIndex:    0,
+		TotalSentences:  1,
+	}
+
+	_, err := lp.Execute(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// debug レベルのログは info ハンドラーでは出力されない
+	if strings.Contains(buf.String(), "llm request") {
+		t.Errorf("expected no debug logs at info level, got: %s", buf.String())
+	}
+}
+
+func TestLoggingProvider_RequestFieldsInLog(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	inner := &mockProvider{
+		responses: []SimulationResponse{
+			{CurrentIndex: 0, NextIndex: nil, Memory: "m", RawResponseText: "raw"},
+		},
+	}
+
+	lp := NewLoggingProvider(inner, logger)
+	req := SimulationRequest{
+		SystemPrompt:    "システムプロンプト",
+		CurrentSentence: "テスト文。",
+		CurrentIndex:    2,
+		TotalSentences:  5,
+		Memory:          "記憶",
+	}
+
+	_, _ = lp.Execute(req)
+
+	// Parse log lines to verify fields
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 log lines, got %d", len(lines))
+	}
+
+	// Check request log
+	var reqLog map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &reqLog); err != nil {
+		t.Fatalf("failed to parse request log: %v", err)
+	}
+	if reqLog["msg"] != "llm request" {
+		t.Errorf("expected 'llm request', got %v", reqLog["msg"])
+	}
+	if int(reqLog["current_index"].(float64)) != 2 {
+		t.Errorf("expected current_index=2, got %v", reqLog["current_index"])
+	}
+
+	// Check response log
+	var respLog map[string]any
+	if err := json.Unmarshal([]byte(lines[1]), &respLog); err != nil {
+		t.Fatalf("failed to parse response log: %v", err)
+	}
+	if respLog["msg"] != "llm response" {
+		t.Errorf("expected 'llm response', got %v", respLog["msg"])
+	}
+	if respLog["raw_response"] != "raw" {
+		t.Errorf("expected raw_response='raw', got %v", respLog["raw_response"])
+	}
+}

--- a/core/provider.go
+++ b/core/provider.go
@@ -22,10 +22,11 @@ type SimulationRequest struct {
 
 // SimulationResponse はAIからの1ステップの出力を表す。
 type SimulationResponse struct {
-	CurrentIndex int    `json:"current_index"`
-	NextIndex    *int   `json:"next_index"` // nil = 読了
-	Note         *Note  `json:"note"`       // nil = 感想なし
-	Memory       string `json:"memory"`
+	CurrentIndex    int    `json:"current_index"`
+	NextIndex       *int   `json:"next_index"` // nil = 読了
+	Note            *Note  `json:"note"`       // nil = 感想なし
+	Memory          string `json:"memory"`
+	RawResponseText string `json:"-"` // デバッグ用。ユーザー向けJSON出力には含まれない
 }
 
 // BuildPrompt はSimulationRequestからLLMに送るシステムプロンプトとユーザーメッセージを構築する。
@@ -124,6 +125,8 @@ func stripMarkdownCodeBlock(text string) string {
 // ParseResponse はAIのテキスト出力からSimulationResponseをパースし、インデックスの範囲を検証する。
 func ParseResponse(text string, totalSentences int) (SimulationResponse, error) {
 	var resp SimulationResponse
+
+	resp.RawResponseText = text
 
 	cleaned := stripMarkdownCodeBlock(text)
 	if err := json.Unmarshal([]byte(cleaned), &resp); err != nil {

--- a/core/simulator.go
+++ b/core/simulator.go
@@ -2,11 +2,12 @@ package core
 
 import (
 	"fmt"
+	"log/slog"
 	"unicode/utf8"
 )
 
 // RunSimulation はドキュメントに対してAI読者シミュレーションを実行し、全ステップを返す。
-func RunSimulation(doc Document, persona Persona, provider Provider) ([]SimulationStep, error) {
+func RunSimulation(doc Document, persona Persona, provider Provider, logger *slog.Logger) ([]SimulationStep, error) {
 	totalSentences := len(doc.Sentences)
 	if totalSentences == 0 {
 		return nil, nil
@@ -16,6 +17,12 @@ func RunSimulation(doc Document, persona Persona, provider Provider) ([]Simulati
 	if maxSteps <= 0 {
 		maxSteps = totalSentences * 3
 	}
+
+	logger.Info("simulation started",
+		"file", doc.ID,
+		"total_sentences", totalSentences,
+		"max_steps", maxSteps,
+	)
 
 	steps := make([]SimulationStep, 0, maxSteps)
 	var memory string
@@ -57,10 +64,22 @@ func RunSimulation(doc Document, persona Persona, provider Provider) ([]Simulati
 			Note:        resp.Note,
 		})
 
+		logger.Info("step completed",
+			"step", step,
+			"current_index", currentIdx,
+			"next_index", resp.NextIndex,
+		)
+
 		// 記憶バッファを更新（memory_capacity で文字数制限）
 		memory = resp.Memory
-		if persona.MemoryCapacity > 0 && utf8.RuneCountInString(memory) > persona.MemoryCapacity {
+		memoryLen := utf8.RuneCountInString(memory)
+		if persona.MemoryCapacity > 0 && memoryLen > persona.MemoryCapacity {
 			memory = string([]rune(memory)[:persona.MemoryCapacity])
+			logger.Warn("memory truncated",
+				"step", step,
+				"original_length", memoryLen,
+				"truncated_length", persona.MemoryCapacity,
+			)
 		}
 
 		if !hasNext {
@@ -69,6 +88,10 @@ func RunSimulation(doc Document, persona Persona, provider Provider) ([]Simulati
 
 		currentIdx = nextIdx
 	}
+
+	logger.Info("simulation finished",
+		"total_steps", len(steps),
+	)
 
 	return steps, nil
 }

--- a/core/simulator_test.go
+++ b/core/simulator_test.go
@@ -1,9 +1,16 @@
 package core
 
 import (
+	"bytes"
 	"errors"
+	"io"
+	"log/slog"
+	"strings"
 	"testing"
 )
+
+// discardLogger はテスト用の出力を破棄するロガー。
+var discardLogger = slog.New(slog.NewJSONHandler(io.Discard, nil))
 
 // mockProvider はテスト用のProviderモック。
 type mockProvider struct {
@@ -55,7 +62,7 @@ func TestRunSimulation_NormalCompletion(t *testing.T) {
 		},
 	}
 
-	steps, err := RunSimulation(doc, persona, mock)
+	steps, err := RunSimulation(doc, persona, mock, discardLogger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -117,7 +124,7 @@ func TestRunSimulation_MaxStepsTermination(t *testing.T) {
 		},
 	}
 
-	steps, err := RunSimulation(doc, persona, mock)
+	steps, err := RunSimulation(doc, persona, mock, discardLogger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -151,7 +158,7 @@ func TestRunSimulation_DefaultMaxSteps(t *testing.T) {
 		},
 	}
 
-	steps, err := RunSimulation(doc, persona, mock)
+	steps, err := RunSimulation(doc, persona, mock, discardLogger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -186,7 +193,7 @@ func TestRunSimulation_ProviderError(t *testing.T) {
 		},
 	}
 
-	_, err := RunSimulation(doc, persona, mock)
+	_, err := RunSimulation(doc, persona, mock, discardLogger)
 	if err == nil {
 		t.Fatal("expected error from provider failure")
 	}
@@ -213,7 +220,7 @@ func TestRunSimulation_OutOfRangeNextIndex(t *testing.T) {
 		},
 	}
 
-	_, err := RunSimulation(doc, persona, mock)
+	_, err := RunSimulation(doc, persona, mock, discardLogger)
 	if err == nil {
 		t.Fatal("expected error for out-of-range next_index")
 	}
@@ -243,7 +250,7 @@ func TestRunSimulation_MemoryCapacityLimit(t *testing.T) {
 		},
 	}
 
-	steps, err := RunSimulation(doc, persona, mock)
+	steps, err := RunSimulation(doc, persona, mock, discardLogger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -281,7 +288,7 @@ func TestRunSimulation_MemoryCapacityAppliedToNextStep(t *testing.T) {
 		},
 	}
 
-	_, err := RunSimulation(doc, persona, mock)
+	_, err := RunSimulation(doc, persona, mock, discardLogger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -321,7 +328,7 @@ func TestRunSimulation_Backtracking(t *testing.T) {
 		},
 	}
 
-	steps, err := RunSimulation(doc, persona, mock)
+	steps, err := RunSimulation(doc, persona, mock, discardLogger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -362,7 +369,7 @@ func TestRunSimulation_RequestFields(t *testing.T) {
 		},
 	}
 
-	_, err := RunSimulation(doc, persona, mock)
+	_, err := RunSimulation(doc, persona, mock, discardLogger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -416,7 +423,7 @@ func TestRunSimulation_EmptyDocument(t *testing.T) {
 	}
 	mock := &mockProvider{}
 
-	steps, err := RunSimulation(doc, persona, mock)
+	steps, err := RunSimulation(doc, persona, mock, discardLogger)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -445,12 +452,88 @@ func TestRunSimulation_NegativeNextIndex(t *testing.T) {
 		},
 	}
 
-	_, err := RunSimulation(doc, persona, mock)
+	_, err := RunSimulation(doc, persona, mock, discardLogger)
 	if err == nil {
 		t.Fatal("expected error for negative next_index")
 	}
 	var idxErr *ErrIndexOutOfRange
 	if !errors.As(err, &idxErr) {
 		t.Errorf("expected ErrIndexOutOfRange, got %T: %v", err, err)
+	}
+}
+
+func TestRunSimulation_LogOutput(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	doc := Document{
+		ID:      "test.txt",
+		RawText: "文1。文2。",
+		Sentences: []Sentence{
+			{Index: 0, Content: "文1。"},
+			{Index: 1, Content: "文2。"},
+		},
+	}
+	persona := Persona{
+		DisplayName:    "テスト",
+		SystemPrompt:   "テスト用",
+		MemoryCapacity: 100,
+		MaxSteps:       10,
+	}
+	mock := &mockProvider{
+		responses: []SimulationResponse{
+			{CurrentIndex: 0, NextIndex: intPtr(1), Memory: "m1"},
+			{CurrentIndex: 1, NextIndex: nil, Memory: "m2"},
+		},
+	}
+
+	_, err := RunSimulation(doc, persona, mock, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	logs := buf.String()
+	if !strings.Contains(logs, "simulation started") {
+		t.Errorf("expected 'simulation started' log")
+	}
+	if !strings.Contains(logs, "step completed") {
+		t.Errorf("expected 'step completed' log")
+	}
+	if !strings.Contains(logs, "simulation finished") {
+		t.Errorf("expected 'simulation finished' log")
+	}
+}
+
+func TestRunSimulation_MemoryTruncationLog(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	doc := Document{
+		ID:      "test.txt",
+		RawText: "文1。",
+		Sentences: []Sentence{
+			{Index: 0, Content: "文1。"},
+		},
+	}
+	persona := Persona{
+		DisplayName:    "テスト",
+		SystemPrompt:   "テスト用",
+		MemoryCapacity: 3,
+		MaxSteps:       10,
+	}
+	mock := &mockProvider{
+		responses: []SimulationResponse{
+			{CurrentIndex: 0, NextIndex: nil, Memory: "あいうえお"},
+		},
+	}
+
+	_, err := RunSimulation(doc, persona, mock, logger)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	logs := buf.String()
+	if !strings.Contains(logs, "memory truncated") {
+		t.Errorf("expected 'memory truncated' warn log, got: %s", logs)
 	}
 }

--- a/docs/draft/spec.md
+++ b/docs/draft/spec.md
@@ -31,6 +31,10 @@
 
 ```json
 {
+  "log": {
+    "level": "info",
+    "path": "/tmp/yomite.log"
+  },
   "default_provider": "local_ollama",
   "default_persona": "beginner",
   "providers": {
@@ -61,6 +65,8 @@
 
 | フィールド | 説明 |
 |---|---|
+| `log.level` | ログレベル（`"debug"`, `"info"`, `"warn"`）。上位は下位を包含する |
+| `log.path` | ログ出力先ファイルパス（必須） |
 | `default_provider` | CLIオプション等で未指定時に使用するプロバイダID |
 | `default_persona` | CLIオプション等で未指定時に使用するペルソナID |
 | `providers.*.type` | プロバイダ種別（MVP では `"ollama"` のみ） |


### PR DESCRIPTION
## Summary

- `log/slog`（標準ライブラリ）ベースの汎用ログ機構を追加
- 設定ファイルに `log` フィールド（`level` / `path`）を必須項目として追加し、JSONL形式でファイル出力
- `LoggingProvider` デコレータで LLM リクエスト/レスポンスを debug レベルで記録
- `RunSimulation` にシミュレーション進行状況の info/warn ロ��を追加
- 仕様書（`docs/draft/spec.md`）の設定例・フィールド表を更新

## Changes

| ファイル | 変更内容 |
|---|---|
| `core/config.go` | `LogConfig` 追加、バリデーション、`ToSlogLevel()` ヘルパー、マージ対応 |
| `core/config_test.go` | LogConfig のバリデー���ョン・マージ・変換テスト追加 |
| `core/provider.go` | `SimulationResponse` に `RawResponseText` フィールド追加 |
| `core/logging_provider.go` | **新規**: `LoggingProvider` デコレータ（debug レベルガード付き） |
| `core/logging_provider_test.go` | **新規**: デコレータのユニットテスト |
| `core/simulator.go` | `RunSimulation` に `*slog.Logger` 引数追加、info/warn ログ出力 |
| `core/simulator_test.go` | Logger 付きテスト追加 |
| `cmd/yomite/run.go` | ログファイルオープン、`slog.Logger` 生成、プロバイダラッピング |
| `cmd/yomite/run_test.go` | ログ出力の結合テスト追加 |
| `docs/draft/spec.md` | 設定例・フィールド表に `log` 追加 |

## Test plan

- [x] `go test ./...` 全テストパス
- [x] `golangci-lint run` 0 issues
- [x] `gofmt` フォーマット問題なし
- [ ] CI パス確認

Closes #39

🤖 Generated with [Claude Code](https://claude.ai/code)