### PR TITLE
feat: runコマンドの結果を1ステップずつ逐次出力する

### DIFF
--- a/cmd/yomite/run.go
+++ b/cmd/yomite/run.go
@@ -117,57 +117,63 @@ func Run(args []string, stdout io.Writer, stderr io.Writer) int {
 
 	provider := core.NewLoggingProvider(providerFactory(providerCfg), logger)
 
-	steps, err := core.RunSimulation(doc, persona, provider, logger)
-	if err != nil {
+	onStep := func(s core.SimulationStep) error {
+		if jsonOutput {
+			return outputStepJSON(stdout, s)
+		}
+		return outputStepText(stdout, s, doc)
+	}
+
+	if err := core.RunSimulation(doc, persona, provider, logger, onStep); err != nil {
 		_, _ = fmt.Fprintf(stderr, "エラー: シミュレーション実行に失敗しました: %v\n", err)
 		return 1
 	}
 
-	if jsonOutput {
-		return outputJSON(stdout, stderr, steps)
-	}
-	return outputText(stdout, steps, doc)
-}
-
-func outputJSON(stdout io.Writer, stderr io.Writer, steps []core.SimulationStep) int {
-	enc := json.NewEncoder(stdout)
-	enc.SetIndent("", "  ")
-	if err := enc.Encode(steps); err != nil {
-		_, _ = fmt.Fprintf(stderr, "エラー: JSON出力に失敗しました: %v\n", err)
-		return 1
-	}
 	return 0
 }
 
-func outputText(stdout io.Writer, steps []core.SimulationStep, doc core.Document) int {
-	for _, s := range steps {
-		sentence := ""
-		if s.SentenceIdx >= 0 && s.SentenceIdx < len(doc.Sentences) {
-			sentence = doc.Sentences[s.SentenceIdx].Content
-		}
-
-		direction := ""
-		if s.TargetIdx != nil {
-			target := *s.TargetIdx
-			switch {
-			case target > s.SentenceIdx:
-				direction = fmt.Sprintf("→ 先読み (→%d)", target)
-			case target < s.SentenceIdx:
-				direction = fmt.Sprintf("← 読み返し (→%d)", target)
-			default:
-				direction = fmt.Sprintf("● 再読 (→%d)", target)
-			}
-		} else {
-			direction = "■ 読了"
-		}
-
-		_, _ = fmt.Fprintf(stdout, "[Step %d] 文%d: %s\n", s.Step, s.SentenceIdx, sentence)
-
-		if s.Note != nil {
-			_, _ = fmt.Fprintf(stdout, "  Note[%s]: %s\n", s.Note.Type, s.Note.Content)
-		}
-
-		_, _ = fmt.Fprintf(stdout, "  %s\n", direction)
+// outputStepJSON は1ステップをJSON Lines形式で出力する。
+func outputStepJSON(w io.Writer, s core.SimulationStep) error {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return err
 	}
-	return 0
+	_, err = fmt.Fprintf(w, "%s\n", data)
+	return err
+}
+
+// outputStepText は1ステップをテキスト形式で出力する。
+func outputStepText(w io.Writer, s core.SimulationStep, doc core.Document) error {
+	sentence := ""
+	if s.SentenceIdx >= 0 && s.SentenceIdx < len(doc.Sentences) {
+		sentence = doc.Sentences[s.SentenceIdx].Content
+	}
+
+	direction := ""
+	if s.TargetIdx != nil {
+		target := *s.TargetIdx
+		switch {
+		case target > s.SentenceIdx:
+			direction = fmt.Sprintf("→ 先読み (→%d)", target)
+		case target < s.SentenceIdx:
+			direction = fmt.Sprintf("← 読み返し (→%d)", target)
+		default:
+			direction = fmt.Sprintf("● 再読 (→%d)", target)
+		}
+	} else {
+		direction = "■ 読了"
+	}
+
+	if _, err := fmt.Fprintf(w, "[Step %d] 文%d: %s\n", s.Step, s.SentenceIdx, sentence); err != nil {
+		return err
+	}
+
+	if s.Note != nil {
+		if _, err := fmt.Fprintf(w, "  Note[%s]: %s\n", s.Note.Type, s.Note.Content); err != nil {
+			return err
+		}
+	}
+
+	_, err := fmt.Fprintf(w, "  %s\n", direction)
+	return err
 }

--- a/cmd/yomite/run_test.go
+++ b/cmd/yomite/run_test.go
@@ -149,17 +149,25 @@ func TestRun_Integration_JSONOutput(t *testing.T) {
 		t.Fatalf("expected exit code 0, got %d; stderr: %s", code, stderr.String())
 	}
 
-	var steps []core.SimulationStep
-	if err := json.Unmarshal(stdout.Bytes(), &steps); err != nil {
-		t.Fatalf("invalid JSON: %v; output: %s", err, stdout.String())
+	// JSON Lines形式: 1行1JSONオブジェクト
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 JSON Lines, got %d; output: %s", len(lines), stdout.String())
 	}
-	if len(steps) != 2 {
-		t.Fatalf("expected 2 steps, got %d", len(steps))
+
+	var step0 core.SimulationStep
+	if err := json.Unmarshal([]byte(lines[0]), &step0); err != nil {
+		t.Fatalf("invalid JSON on line 0: %v; line: %s", err, lines[0])
 	}
-	if steps[0].TargetIdx == nil || *steps[0].TargetIdx != 1 {
+	if step0.TargetIdx == nil || *step0.TargetIdx != 1 {
 		t.Errorf("expected target_idx=1 in step 0")
 	}
-	if steps[1].TargetIdx != nil {
+
+	var step1 core.SimulationStep
+	if err := json.Unmarshal([]byte(lines[1]), &step1); err != nil {
+		t.Fatalf("invalid JSON on line 1: %v; line: %s", err, lines[1])
+	}
+	if step1.TargetIdx != nil {
 		t.Errorf("expected nil target_idx in step 1")
 	}
 }
@@ -225,45 +233,59 @@ func TestRun_PersonaNotFound(t *testing.T) {
 	}
 }
 
-func TestOutputJSON(t *testing.T) {
-	steps := []core.SimulationStep{
-		{
-			Step:        0,
-			SentenceIdx: 0,
-			TargetIdx:   intPtr(1),
-			Note:        &core.Note{Type: core.NoteTypeQuestion, Content: "テスト疑問"},
-		},
-		{
-			Step:        1,
-			SentenceIdx: 1,
-			TargetIdx:   nil,
-			Note:        nil,
-		},
+func TestOutputStepJSON(t *testing.T) {
+	step := core.SimulationStep{
+		Step:        0,
+		SentenceIdx: 0,
+		TargetIdx:   intPtr(1),
+		Note:        &core.Note{Type: core.NoteTypeQuestion, Content: "テスト疑問"},
 	}
 
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	code := outputJSON(&stdout, &stderr, steps)
-	if code != 0 {
-		t.Fatalf("expected exit code 0, got %d", code)
+	var buf bytes.Buffer
+	if err := outputStepJSON(&buf, step); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var result []core.SimulationStep
-	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
-		t.Fatalf("invalid JSON output: %v", err)
+	output := strings.TrimSpace(buf.String())
+	var result core.SimulationStep
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v; output: %s", err, output)
 	}
-	if len(result) != 2 {
-		t.Fatalf("expected 2 steps, got %d", len(result))
+	if result.Note == nil || result.Note.Type != core.NoteTypeQuestion {
+		t.Errorf("expected QUESTION note")
 	}
-	if result[0].Note == nil || result[0].Note.Type != core.NoteTypeQuestion {
-		t.Errorf("expected QUESTION note in step 0")
-	}
-	if result[1].TargetIdx != nil {
-		t.Errorf("expected nil target_idx in step 1")
+	if result.TargetIdx == nil || *result.TargetIdx != 1 {
+		t.Errorf("expected target_idx=1")
 	}
 }
 
-func TestOutputText(t *testing.T) {
+func TestOutputStepJSON_NilFields(t *testing.T) {
+	step := core.SimulationStep{
+		Step:        1,
+		SentenceIdx: 1,
+		TargetIdx:   nil,
+		Note:        nil,
+	}
+
+	var buf bytes.Buffer
+	if err := outputStepJSON(&buf, step); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := strings.TrimSpace(buf.String())
+	var result core.SimulationStep
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("invalid JSON output: %v", err)
+	}
+	if result.TargetIdx != nil {
+		t.Errorf("expected nil target_idx")
+	}
+	if result.Note != nil {
+		t.Errorf("expected nil note")
+	}
+}
+
+func TestOutputStepText(t *testing.T) {
 	doc := core.Document{
 		ID:      "test",
 		RawText: "文1。文2。",
@@ -295,9 +317,10 @@ func TestOutputText(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	code := outputText(&stdout, steps, doc)
-	if code != 0 {
-		t.Fatalf("expected exit code 0, got %d", code)
+	for _, s := range steps {
+		if err := outputStepText(&stdout, s, doc); err != nil {
+			t.Fatalf("unexpected error at step %d: %v", s.Step, err)
+		}
 	}
 
 	output := stdout.String()
@@ -327,25 +350,22 @@ func TestOutputText(t *testing.T) {
 	}
 }
 
-func TestOutputText_Reread(t *testing.T) {
+func TestOutputStepText_Reread(t *testing.T) {
 	doc := core.Document{
 		Sentences: []core.Sentence{
 			{Index: 0, Content: "テスト。"},
 		},
 	}
 
-	steps := []core.SimulationStep{
-		{
-			Step:        0,
-			SentenceIdx: 0,
-			TargetIdx:   intPtr(0),
-		},
+	step := core.SimulationStep{
+		Step:        0,
+		SentenceIdx: 0,
+		TargetIdx:   intPtr(0),
 	}
 
 	var stdout bytes.Buffer
-	code := outputText(&stdout, steps, doc)
-	if code != 0 {
-		t.Fatalf("expected exit code 0, got %d", code)
+	if err := outputStepText(&stdout, step, doc); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strings.Contains(stdout.String(), "再読") {
 		t.Errorf("expected reread direction, got: %s", stdout.String())

--- a/core/simulator.go
+++ b/core/simulator.go
@@ -6,11 +6,13 @@ import (
 	"unicode/utf8"
 )
 
-// RunSimulation はドキュメントに対してAI読者シミュレーションを実行し、全ステップを返す。
-func RunSimulation(doc Document, persona Persona, provider Provider, logger *slog.Logger) ([]SimulationStep, error) {
+// RunSimulation はドキュメントに対してAI読者シミュレーションを実行する。
+// 各ステップが完了するたびに onStep コールバックを呼び出し、結果を逐次的に返す。
+// onStep がエラーを返した場合、シミュレーションを中断しそのエラーを返す。
+func RunSimulation(doc Document, persona Persona, provider Provider, logger *slog.Logger, onStep func(SimulationStep) error) error {
 	totalSentences := len(doc.Sentences)
 	if totalSentences == 0 {
-		return nil, nil
+		return nil
 	}
 
 	maxSteps := persona.MaxSteps
@@ -24,9 +26,9 @@ func RunSimulation(doc Document, persona Persona, provider Provider, logger *slo
 		"max_steps", maxSteps,
 	)
 
-	steps := make([]SimulationStep, 0, maxSteps)
 	var memory string
 	currentIdx := 0
+	completedSteps := 0
 
 	for step := 0; step < maxSteps; step++ {
 		req := SimulationRequest{
@@ -39,7 +41,7 @@ func RunSimulation(doc Document, persona Persona, provider Provider, logger *slo
 
 		resp, err := provider.Execute(req)
 		if err != nil {
-			return nil, fmt.Errorf("step %d: provider error: %w", step, err)
+			return fmt.Errorf("step %d: provider error: %w", step, err)
 		}
 
 		var nextIdx int
@@ -47,7 +49,7 @@ func RunSimulation(doc Document, persona Persona, provider Provider, logger *slo
 		if hasNext {
 			nextIdx = *resp.NextIndex
 			if nextIdx < 0 || nextIdx >= totalSentences {
-				return nil, &ErrIndexOutOfRange{
+				return &ErrIndexOutOfRange{
 					Field: "next_index",
 					Index: nextIdx,
 					Max:   totalSentences,
@@ -57,12 +59,16 @@ func RunSimulation(doc Document, persona Persona, provider Provider, logger *slo
 		// NOTE: ParseResponse が next_index==totalSentences を nil に変換済みなので
 		// ここでは追加の境界補正は不要。
 
-		steps = append(steps, SimulationStep{
+		s := SimulationStep{
 			Step:        step,
 			SentenceIdx: currentIdx,
 			TargetIdx:   resp.NextIndex,
 			Note:        resp.Note,
-		})
+		}
+		if err := onStep(s); err != nil {
+			return fmt.Errorf("step %d: callback error: %w", step, err)
+		}
+		completedSteps++
 
 		logger.Info("step completed",
 			"step", step,
@@ -70,7 +76,6 @@ func RunSimulation(doc Document, persona Persona, provider Provider, logger *slo
 			"next_index", resp.NextIndex,
 		)
 
-		// 記憶バッファを更新（memory_capacity で文字数制限）
 		memory = resp.Memory
 		memoryLen := utf8.RuneCountInString(memory)
 		if persona.MemoryCapacity > 0 && memoryLen > persona.MemoryCapacity {
@@ -90,8 +95,8 @@ func RunSimulation(doc Document, persona Persona, provider Provider, logger *slo
 	}
 
 	logger.Info("simulation finished",
-		"total_steps", len(steps),
+		"total_steps", completedSteps,
 	)
 
-	return steps, nil
+	return nil
 }

--- a/core/simulator_test.go
+++ b/core/simulator_test.go
@@ -37,6 +37,19 @@ func intPtr(v int) *int {
 	return &v
 }
 
+// collectSteps はコールバックで受け取ったステップをスライスに集めるヘルパー。
+func collectSteps() (onStep func(SimulationStep) error, getSteps func() []SimulationStep) {
+	var steps []SimulationStep
+	onStep = func(s SimulationStep) error {
+		steps = append(steps, s)
+		return nil
+	}
+	getSteps = func() []SimulationStep {
+		return steps
+	}
+	return
+}
+
 func TestRunSimulation_NormalCompletion(t *testing.T) {
 	// 3文のドキュメントを順に読み、2文目でnilを返して終了
 	doc := Document{
@@ -62,11 +75,13 @@ func TestRunSimulation_NormalCompletion(t *testing.T) {
 		},
 	}
 
-	steps, err := RunSimulation(doc, persona, mock, discardLogger)
+	onStep, getSteps := collectSteps()
+	err := RunSimulation(doc, persona, mock, discardLogger, onStep)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	steps := getSteps()
 	if len(steps) != 3 {
 		t.Fatalf("expected 3 steps, got %d", len(steps))
 	}
@@ -112,30 +127,30 @@ func TestRunSimulation_MaxStepsTermination(t *testing.T) {
 		DisplayName:    "テスト",
 		SystemPrompt:   "テスト用",
 		MemoryCapacity: 100,
-		MaxSteps:       3, // 明示的にmax_stepsを指定
+		MaxSteps:       3,
 	}
-	// 永遠にループするレスポンス
 	mock := &mockProvider{
 		responses: []SimulationResponse{
 			{CurrentIndex: 0, NextIndex: intPtr(1), Memory: "m1"},
 			{CurrentIndex: 1, NextIndex: intPtr(0), Memory: "m2"},
 			{CurrentIndex: 0, NextIndex: intPtr(1), Memory: "m3"},
-			{CurrentIndex: 1, NextIndex: intPtr(0), Memory: "m4"}, // ここには到達しない
+			{CurrentIndex: 1, NextIndex: intPtr(0), Memory: "m4"},
 		},
 	}
 
-	steps, err := RunSimulation(doc, persona, mock, discardLogger)
+	onStep, getSteps := collectSteps()
+	err := RunSimulation(doc, persona, mock, discardLogger, onStep)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	steps := getSteps()
 	if len(steps) != 3 {
 		t.Fatalf("expected 3 steps (max_steps), got %d", len(steps))
 	}
 }
 
 func TestRunSimulation_DefaultMaxSteps(t *testing.T) {
-	// MaxSteps=0 の場合、デフォルト (文数×3) が使用される
 	doc := Document{
 		ID:      "test",
 		RawText: "文1。",
@@ -147,22 +162,24 @@ func TestRunSimulation_DefaultMaxSteps(t *testing.T) {
 		DisplayName:    "テスト",
 		SystemPrompt:   "テスト用",
 		MemoryCapacity: 100,
-		MaxSteps:       0, // デフォルト: 1×3=3
+		MaxSteps:       0,
 	}
 	mock := &mockProvider{
 		responses: []SimulationResponse{
 			{CurrentIndex: 0, NextIndex: intPtr(0), Memory: "m1"},
 			{CurrentIndex: 0, NextIndex: intPtr(0), Memory: "m2"},
 			{CurrentIndex: 0, NextIndex: intPtr(0), Memory: "m3"},
-			{CurrentIndex: 0, NextIndex: intPtr(0), Memory: "m4"}, // 到達しない
+			{CurrentIndex: 0, NextIndex: intPtr(0), Memory: "m4"},
 		},
 	}
 
-	steps, err := RunSimulation(doc, persona, mock, discardLogger)
+	onStep, getSteps := collectSteps()
+	err := RunSimulation(doc, persona, mock, discardLogger, onStep)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	steps := getSteps()
 	if len(steps) != 3 {
 		t.Fatalf("expected 3 steps (default max_steps=sentences*3), got %d", len(steps))
 	}
@@ -193,7 +210,8 @@ func TestRunSimulation_ProviderError(t *testing.T) {
 		},
 	}
 
-	_, err := RunSimulation(doc, persona, mock, discardLogger)
+	onStep, _ := collectSteps()
+	err := RunSimulation(doc, persona, mock, discardLogger, onStep)
 	if err == nil {
 		t.Fatal("expected error from provider failure")
 	}
@@ -216,11 +234,12 @@ func TestRunSimulation_OutOfRangeNextIndex(t *testing.T) {
 	}
 	mock := &mockProvider{
 		responses: []SimulationResponse{
-			{CurrentIndex: 0, NextIndex: intPtr(99), Memory: "m1"}, // 範囲外
+			{CurrentIndex: 0, NextIndex: intPtr(99), Memory: "m1"},
 		},
 	}
 
-	_, err := RunSimulation(doc, persona, mock, discardLogger)
+	onStep, _ := collectSteps()
+	err := RunSimulation(doc, persona, mock, discardLogger, onStep)
 	if err == nil {
 		t.Fatal("expected error for out-of-range next_index")
 	}
@@ -241,26 +260,25 @@ func TestRunSimulation_MemoryCapacityLimit(t *testing.T) {
 	persona := Persona{
 		DisplayName:    "テスト",
 		SystemPrompt:   "テスト用",
-		MemoryCapacity: 5, // 5文字まで
+		MemoryCapacity: 5,
 		MaxSteps:       10,
 	}
 	mock := &mockProvider{
 		responses: []SimulationResponse{
-			{CurrentIndex: 0, NextIndex: nil, Memory: "これは長い記憶バッファです"}, // 12文字 → 5文字に切り詰め
+			{CurrentIndex: 0, NextIndex: nil, Memory: "これは長い記憶バッファです"},
 		},
 	}
 
-	steps, err := RunSimulation(doc, persona, mock, discardLogger)
+	onStep, getSteps := collectSteps()
+	err := RunSimulation(doc, persona, mock, discardLogger, onStep)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	steps := getSteps()
 	if len(steps) != 1 {
 		t.Fatalf("expected 1 step, got %d", len(steps))
 	}
 
-	// 次のリクエストに渡されるmemoryが制限されていることを確認
-	// この場合はステップ1つで終了するので、mockへのリクエストのmemoryを検証
-	// 最初のリクエストのmemoryは空
 	if mock.calls[0].Memory != "" {
 		t.Errorf("first request should have empty memory, got %q", mock.calls[0].Memory)
 	}
@@ -278,22 +296,22 @@ func TestRunSimulation_MemoryCapacityAppliedToNextStep(t *testing.T) {
 	persona := Persona{
 		DisplayName:    "テスト",
 		SystemPrompt:   "テスト用",
-		MemoryCapacity: 3, // 3文字まで
+		MemoryCapacity: 3,
 		MaxSteps:       10,
 	}
 	mock := &mockProvider{
 		responses: []SimulationResponse{
-			{CurrentIndex: 0, NextIndex: intPtr(1), Memory: "あいうえお"}, // 5文字 → 3文字に切り詰め
+			{CurrentIndex: 0, NextIndex: intPtr(1), Memory: "あいうえお"},
 			{CurrentIndex: 1, NextIndex: nil, Memory: "ok"},
 		},
 	}
 
-	_, err := RunSimulation(doc, persona, mock, discardLogger)
+	onStep, _ := collectSteps()
+	err := RunSimulation(doc, persona, mock, discardLogger, onStep)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// 2回目のリクエストで、memoryが3文字に切り詰められていることを確認
 	if len(mock.calls) < 2 {
 		t.Fatalf("expected at least 2 calls, got %d", len(mock.calls))
 	}
@@ -303,7 +321,6 @@ func TestRunSimulation_MemoryCapacityAppliedToNextStep(t *testing.T) {
 }
 
 func TestRunSimulation_Backtracking(t *testing.T) {
-	// AIが後戻りするケース
 	doc := Document{
 		ID:      "test",
 		RawText: "文1。文2。文3。",
@@ -322,22 +339,23 @@ func TestRunSimulation_Backtracking(t *testing.T) {
 	mock := &mockProvider{
 		responses: []SimulationResponse{
 			{CurrentIndex: 0, NextIndex: intPtr(1), Memory: "m1"},
-			{CurrentIndex: 1, NextIndex: intPtr(0), Memory: "m2"}, // 後戻り
-			{CurrentIndex: 0, NextIndex: intPtr(2), Memory: "m3"}, // スキップ
+			{CurrentIndex: 1, NextIndex: intPtr(0), Memory: "m2"},
+			{CurrentIndex: 0, NextIndex: intPtr(2), Memory: "m3"},
 			{CurrentIndex: 2, NextIndex: nil, Memory: "m4"},
 		},
 	}
 
-	steps, err := RunSimulation(doc, persona, mock, discardLogger)
+	onStep, getSteps := collectSteps()
+	err := RunSimulation(doc, persona, mock, discardLogger, onStep)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	steps := getSteps()
 	if len(steps) != 4 {
 		t.Fatalf("expected 4 steps, got %d", len(steps))
 	}
 
-	// 後戻り確認
 	if steps[1].TargetIdx == nil || *steps[1].TargetIdx != 0 {
 		t.Errorf("step 1 should backtrack to 0")
 	}
@@ -347,7 +365,6 @@ func TestRunSimulation_Backtracking(t *testing.T) {
 }
 
 func TestRunSimulation_RequestFields(t *testing.T) {
-	// Provider.Execute に正しいリクエストが渡されることを確認
 	doc := Document{
 		ID:      "test",
 		RawText: "文1。文2。",
@@ -369,7 +386,8 @@ func TestRunSimulation_RequestFields(t *testing.T) {
 		},
 	}
 
-	_, err := RunSimulation(doc, persona, mock, discardLogger)
+	onStep, _ := collectSteps()
+	err := RunSimulation(doc, persona, mock, discardLogger, onStep)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -378,7 +396,6 @@ func TestRunSimulation_RequestFields(t *testing.T) {
 		t.Fatalf("expected 2 calls, got %d", len(mock.calls))
 	}
 
-	// 1回目のリクエスト
 	req0 := mock.calls[0]
 	if req0.SystemPrompt != "あなたはテスト用AIです" {
 		t.Errorf("req0.SystemPrompt: got %q", req0.SystemPrompt)
@@ -396,7 +413,6 @@ func TestRunSimulation_RequestFields(t *testing.T) {
 		t.Errorf("req0.Memory: got %q, want empty", req0.Memory)
 	}
 
-	// 2回目のリクエスト
 	req1 := mock.calls[1]
 	if req1.CurrentSentence != "文2。" {
 		t.Errorf("req1.CurrentSentence: got %q", req1.CurrentSentence)
@@ -423,12 +439,13 @@ func TestRunSimulation_EmptyDocument(t *testing.T) {
 	}
 	mock := &mockProvider{}
 
-	steps, err := RunSimulation(doc, persona, mock, discardLogger)
+	onStep, getSteps := collectSteps()
+	err := RunSimulation(doc, persona, mock, discardLogger, onStep)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(steps) != 0 {
-		t.Errorf("expected 0 steps for empty document, got %d", len(steps))
+	if len(getSteps()) != 0 {
+		t.Errorf("expected 0 steps for empty document, got %d", len(getSteps()))
 	}
 }
 
@@ -448,11 +465,12 @@ func TestRunSimulation_NegativeNextIndex(t *testing.T) {
 	}
 	mock := &mockProvider{
 		responses: []SimulationResponse{
-			{CurrentIndex: 0, NextIndex: intPtr(-1), Memory: "m1"}, // 負のインデックス
+			{CurrentIndex: 0, NextIndex: intPtr(-1), Memory: "m1"},
 		},
 	}
 
-	_, err := RunSimulation(doc, persona, mock, discardLogger)
+	onStep, _ := collectSteps()
+	err := RunSimulation(doc, persona, mock, discardLogger, onStep)
 	if err == nil {
 		t.Fatal("expected error for negative next_index")
 	}
@@ -487,7 +505,8 @@ func TestRunSimulation_LogOutput(t *testing.T) {
 		},
 	}
 
-	_, err := RunSimulation(doc, persona, mock, logger)
+	onStep, _ := collectSteps()
+	err := RunSimulation(doc, persona, mock, logger, onStep)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -527,7 +546,8 @@ func TestRunSimulation_MemoryTruncationLog(t *testing.T) {
 		},
 	}
 
-	_, err := RunSimulation(doc, persona, mock, logger)
+	onStep, _ := collectSteps()
+	err := RunSimulation(doc, persona, mock, logger, onStep)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -535,5 +555,87 @@ func TestRunSimulation_MemoryTruncationLog(t *testing.T) {
 	logs := buf.String()
 	if !strings.Contains(logs, "memory truncated") {
 		t.Errorf("expected 'memory truncated' warn log, got: %s", logs)
+	}
+}
+
+func TestRunSimulation_CallbackCalledPerStep(t *testing.T) {
+	doc := Document{
+		ID:      "test",
+		RawText: "文1。文2。",
+		Sentences: []Sentence{
+			{Index: 0, Content: "文1。"},
+			{Index: 1, Content: "文2。"},
+		},
+	}
+	persona := Persona{
+		DisplayName:    "テスト",
+		SystemPrompt:   "テスト用",
+		MemoryCapacity: 100,
+		MaxSteps:       10,
+	}
+	mock := &mockProvider{
+		responses: []SimulationResponse{
+			{CurrentIndex: 0, NextIndex: intPtr(1), Memory: "m1"},
+			{CurrentIndex: 1, NextIndex: nil, Memory: "m2"},
+		},
+	}
+
+	var callOrder []int
+	onStep := func(s SimulationStep) error {
+		callOrder = append(callOrder, s.Step)
+		return nil
+	}
+	err := RunSimulation(doc, persona, mock, discardLogger, onStep)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(callOrder) != 2 {
+		t.Fatalf("expected 2 callback calls, got %d", len(callOrder))
+	}
+	if callOrder[0] != 0 || callOrder[1] != 1 {
+		t.Errorf("expected callback order [0, 1], got %v", callOrder)
+	}
+}
+
+func TestRunSimulation_CallbackError(t *testing.T) {
+	doc := Document{
+		ID:      "test",
+		RawText: "文1。文2。",
+		Sentences: []Sentence{
+			{Index: 0, Content: "文1。"},
+			{Index: 1, Content: "文2。"},
+		},
+	}
+	persona := Persona{
+		DisplayName:    "テスト",
+		SystemPrompt:   "テスト用",
+		MemoryCapacity: 100,
+		MaxSteps:       10,
+	}
+	mock := &mockProvider{
+		responses: []SimulationResponse{
+			{CurrentIndex: 0, NextIndex: intPtr(1), Memory: "m1"},
+			{CurrentIndex: 1, NextIndex: nil, Memory: "m2"},
+		},
+	}
+
+	callbackErr := errors.New("output failed")
+	onStep := func(s SimulationStep) error {
+		if s.Step == 0 {
+			return callbackErr
+		}
+		return nil
+	}
+	err := RunSimulation(doc, persona, mock, discardLogger, onStep)
+	if err == nil {
+		t.Fatal("expected error from callback failure")
+	}
+	if !errors.Is(err, callbackErr) {
+		t.Errorf("expected callback error to be wrapped, got: %v", err)
+	}
+	// プロバイダは1回だけ呼ばれる（コールバックエラーで中断）
+	if mock.callIdx != 1 {
+		t.Errorf("expected provider to be called once, got %d", mock.callIdx)
 	}
 }

--- a/docs/draft/spec.md
+++ b/docs/draft/spec.md
@@ -223,7 +223,7 @@ type Note struct {
 | `-f` | 入力テキストファイルのパス |
 | `--provider` | 使用するプロバイダIDを指定（未指定時は `default_provider`） |
 | `--persona` | 使用するペルソナIDを指定（未指定時は `default_persona`） |
-| `--json` | 出力をJSON形式に切替 |
+| `--json` | 出力をJSON Lines形式に切替（1ステップ1行） |
 | `--config` | config.jsonのパスを明示指定 |
 
 ### 5.3 設定管理


### PR DESCRIPTION
## Summary

- `RunSimulation`のインターフェースをコールバック方式(`onStep func(SimulationStep) error`)に変更し、各ステップ完了時に即座にstdoutへ書き出すようにした
- JSON出力をJSON配列形式からJSON Lines形式に変更（破壊的変更）
- spec.mdの`--json`フラグ説明をJSON Lines形式に更新

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `core/simulator.go` | `RunSimulation`の戻り値を`([]SimulationStep, error)`からコールバック+`error`に変更 |
| `cmd/yomite/run.go` | `outputStepJSON`/`outputStepText`で1ステップごとに逐次出力 |
| `core/simulator_test.go` | `collectSteps`ヘルパー追加、コールバックエラーテスト追加 |
| `cmd/yomite/run_test.go` | JSON Lines形式パース、ステップ単位テストに更新 |
| `docs/draft/spec.md` | `--json`フラグの説明をJSON Lines形式に更新 |

## Test plan

- [x] `go test ./...` 全テストパス
- [x] `gofmt` / `golangci-lint run` クリーン
- [ ] 実環境でのLLM接続による動作確認（手動）

Closes #43

🤖 Generated with [Claude Code](https://claude.ai/code)