### PR TITLE
feat: React/Tailwindフロントエンド雛形 + エディタコンポーネント

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,44 +1,63 @@
-import { useState } from 'react';
-import { Greet } from '../wailsjs/go/main/App';
+import { useState } from "react";
+import { Editor } from "./components/Editor";
+import { SentenceList } from "./components/SentenceList";
+import type { Sentence } from "./types";
+
+// NOTE: Go側のLoadDocumentバインディングが未接続のため、
+// クライアント側で簡易的に文分割を行うスタブ実装。
+// 正確な分割ロジックはGo側(core/document.go)にあり、バインディング接続時に置き換える。
+function splitSentencesStub(text: string): Sentence[] {
+  return text
+    .split(/(?<=[。！？」])|(?<=[.!?])\s/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((content, index) => ({ index, content }));
+}
 
 function App() {
-  const [name, setName] = useState('');
-  const [result, setResult] = useState('');
+  const [sentences, setSentences] = useState<Sentence[]>([]);
 
-  async function greet() {
-    if (!name.trim()) return;
-    try {
-      const greeting = await Greet(name);
-      setResult(greeting);
-    } catch (e) {
-      setResult(`エラー: ${e}`);
-    }
+  function handleLoadDocument(text: string) {
+    // TODO: LoadDocumentバインディングに置き換え
+    const result = splitSentencesStub(text);
+    setSentences(result);
   }
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 p-8">
-      <h1 className="text-4xl font-bold mb-8">yomite</h1>
-      <div className="flex gap-2 mb-4">
-        <input
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && greet()}
-          placeholder="名前を入力"
-          className="px-4 py-2 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
-        />
-        <button
-          onClick={greet}
-          className="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
-        >
-          Greet
-        </button>
+    <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+      <header className="shrink-0 px-6 py-3 border-b border-gray-200 dark:border-gray-700">
+        <h1 className="text-xl font-bold">yomite</h1>
+      </header>
+
+      <div className="flex-1 flex min-h-0">
+        {/* 左パネル: エディタ */}
+        <section className="w-1/2 p-4 border-r border-gray-200 dark:border-gray-700 flex flex-col">
+          <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 mb-2">
+            ドキュメント
+          </h2>
+          <div className="flex-1 flex flex-col min-h-0">
+            <Editor onLoadDocument={handleLoadDocument} />
+          </div>
+          {sentences.length > 0 && (
+            <div className="mt-4 overflow-y-auto max-h-[40%]">
+              <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 mb-2">
+                文一覧
+              </h2>
+              <SentenceList sentences={sentences} />
+            </div>
+          )}
+        </section>
+
+        {/* 右パネル: シミュレーション結果（プレースホルダー） */}
+        <section className="w-1/2 p-4 flex flex-col">
+          <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 mb-2">
+            シミュレーション結果
+          </h2>
+          <div className="flex-1 flex items-center justify-center text-gray-400 dark:text-gray-500">
+            <p>シミュレーション結果がここに表示されます</p>
+          </div>
+        </section>
       </div>
-      {result && (
-        <p className="text-lg mt-4 p-4 bg-white dark:bg-gray-800 rounded shadow">
-          {result}
-        </p>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/Editor.tsx
+++ b/frontend/src/components/Editor.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+
+const PROVIDERS = ["ollama"] as const;
+const PERSONAS = ["default"] as const;
+
+interface EditorProps {
+  onLoadDocument: (text: string) => void;
+}
+
+export function Editor({ onLoadDocument }: EditorProps) {
+  const [text, setText] = useState("");
+  // NOTE: provider/personaはGoバインディング接続時にコールバック経由で渡す予定。
+  // 現時点ではUI表示のみで実行時には未使用。
+  const [provider, setProvider] = useState<string>(PROVIDERS[0]);
+  const [persona, setPersona] = useState<string>(PERSONAS[0]);
+
+  function handleRun() {
+    if (!text.trim()) return;
+    onLoadDocument(text);
+  }
+
+  return (
+    <div className="flex flex-col gap-4 h-full">
+      <div className="flex gap-2">
+        <label className="flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400">
+          プロバイダ
+          <select
+            value={provider}
+            onChange={(e) => setProvider(e.target.value)}
+            className="px-2 py-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm"
+          >
+            {PROVIDERS.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400">
+          ペルソナ
+          <select
+            value={persona}
+            onChange={(e) => setPersona(e.target.value)}
+            className="px-2 py-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm"
+          >
+            {PERSONAS.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="文章を入力してください…"
+        className="flex-1 min-h-[200px] p-3 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 resize-none focus:outline-none focus:ring-2 focus:ring-blue-500"
+      />
+
+      <button
+        onClick={handleRun}
+        disabled={!text.trim()}
+        className="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors self-end"
+      >
+        実行
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/SentenceList.tsx
+++ b/frontend/src/components/SentenceList.tsx
@@ -1,0 +1,23 @@
+import type { Sentence } from "../types";
+
+interface SentenceListProps {
+  sentences: Sentence[];
+}
+
+export function SentenceList({ sentences }: SentenceListProps) {
+  return (
+    <ol className="flex flex-col gap-2">
+      {sentences.map((sentence) => (
+        <li
+          key={sentence.index}
+          className="flex gap-3 p-3 rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
+        >
+          <span className="shrink-0 w-8 h-8 flex items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 text-sm font-bold">
+            {sentence.index + 1}
+          </span>
+          <span className="pt-1">{sentence.content}</span>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,19 @@
+export type NoteType = "QUESTION" | "RESOLVED" | "CONFUSION";
+
+export interface Sentence {
+  index: number;
+  content: string;
+}
+
+// NOTE: Go側のJSONタグ(json:"current_index"等)に合わせてスネークケースを使用
+export interface SimulationStep {
+  step: number;
+  current_index: number;
+  next_index: number | null;
+  note: Note | null;
+}
+
+export interface Note {
+  type: NoteType;
+  content: string;
+}


### PR DESCRIPTION
## Summary

- 2パネルレイアウト（左: ドキュメントエディタ、右: シミュレーション結果プレースホルダー）を構築
- `Editor` コンポーネント: テキストエリア、実行ボタン、プロバイダ/ペルソナ選択ドロップダウン（固定値）
- `SentenceList` コンポーネント: 入力文章を文単位で番号付きブロック表示
- TypeScript型定義（`Sentence`, `SimulationStep`, `Note`, `NoteType`）をGo `core/types.go` と対応

Closes #54

## Test plan

- [ ] `npm run build` が成功する
- [ ] `npm run lint` がエラーなく通る
- [ ] テキストエリアに文章を入力できる
- [ ] 「実行」ボタンを押すと文が番号付きブロックで表示される
- [ ] 2パネルレイアウトが正しく表示される
- [ ] プロバイダ/ペルソナ選択ドロップダウンが表示される

🤖 Generated with [Claude Code](https://claude.ai/code)