### PR TITLE
feat: Goバインディング層 — core/をフロントエンドに公開

### DIFF
--- a/app.go
+++ b/app.go
@@ -2,22 +2,157 @@
 
 package main
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
 
-// NOTE: ctx をフィールドに保持するのは Wails v2 の標準パターン。
-// OnStartup コールバックで渡され、Wails ランタイム API の呼び出しに必要。
+	"github.com/canpok1/yomite/core"
+	wailsRuntime "github.com/wailsapp/wails/v2/pkg/runtime"
+)
+
+const (
+	eventSimulationStep  = "simulation:step"
+	eventSimulationDone  = "simulation:done"
+	eventSimulationError = "simulation:error"
+)
+
+// App はWailsバインディング層。core/ パッケージの機能をフロントエンドに公開する。
 type App struct {
-	ctx context.Context
+	ctx    context.Context
+	cancel context.CancelFunc
+	mu     sync.Mutex
+
+	providerFactory func(cfg core.ProviderConfig) core.Provider
+	emitEvent       func(eventName string, data ...any)
 }
 
 func NewApp() *App {
-	return &App{}
+	a := &App{}
+	a.providerFactory = func(cfg core.ProviderConfig) core.Provider {
+		return core.NewOllamaProvider(cfg.Origin, cfg.Model)
+	}
+	a.emitEvent = func(eventName string, data ...any) {
+		wailsRuntime.EventsEmit(a.ctx, eventName, data...)
+	}
+	return a
 }
 
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
 }
 
-func (a *App) Greet(name string) string {
-	return "Hello " + name + ", welcome to yomite!"
+// LoadDocument はテキストを文分割して返す。
+func (a *App) LoadDocument(rawText string) []core.Sentence {
+	doc := core.Document{RawText: rawText}
+	return doc.SplitSentences()
+}
+
+// GetConfig は設定ファイルを読み込んで返す。
+func (a *App) GetConfig() (*core.Config, error) {
+	return core.LoadConfig("")
+}
+
+// ListProviders は利用可能なプロバイダID一覧を返す。
+func (a *App) ListProviders() ([]string, error) {
+	cfg, err := core.LoadConfig("")
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, 0, len(cfg.Providers))
+	for id := range cfg.Providers {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids, nil
+}
+
+// ListPersonas はペルソナID→表示名のマッピングを返す。
+func (a *App) ListPersonas() (map[string]string, error) {
+	cfg, err := core.LoadConfig("")
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]string, len(cfg.Personas))
+	for id, p := range cfg.Personas {
+		result[id] = p.DisplayName
+	}
+	return result, nil
+}
+
+// StartSimulation はgoroutineでシミュレーションを実行し、Wails Eventsで逐次通知する。
+func (a *App) StartSimulation(rawText, providerID, personaID string) error {
+	cfg, err := core.LoadConfig("")
+	if err != nil {
+		return err
+	}
+
+	providerCfg, ok := cfg.Providers[providerID]
+	if !ok {
+		return fmt.Errorf("プロバイダ %q が設定に存在しません", providerID)
+	}
+
+	persona, ok := cfg.Personas[personaID]
+	if !ok {
+		return fmt.Errorf("ペルソナ %q が設定に存在しません", personaID)
+	}
+
+	doc := core.Document{ID: "gui-input", RawText: rawText}
+	doc.Sentences = doc.SplitSentences()
+
+	provider := a.providerFactory(providerCfg)
+
+	// NOTE: cancel の読み書きのみをロックで保護する。
+	// goroutine起動をロック内に入れると呼び出し元がブロックされるため、ロック外で起動する。
+	a.mu.Lock()
+	if a.cancel != nil {
+		a.mu.Unlock()
+		return fmt.Errorf("シミュレーションが既に実行中です")
+	}
+	ctx, cancel := context.WithCancel(a.ctx)
+	a.cancel = cancel
+	a.mu.Unlock()
+
+	go a.runSimulation(ctx, doc, persona, provider)
+
+	return nil
+}
+
+// runSimulation はシミュレーションを実行し、結果をWails Eventsで通知する。
+func (a *App) runSimulation(ctx context.Context, doc core.Document, persona core.Persona, provider core.Provider) {
+	defer func() {
+		a.mu.Lock()
+		a.cancel = nil
+		a.mu.Unlock()
+	}()
+
+	logger := slog.Default()
+
+	onStep := func(s core.SimulationStep) error {
+		a.emitEvent(eventSimulationStep, s)
+		return ctx.Err()
+	}
+
+	if err := core.RunSimulation(doc, persona, provider, logger, onStep); err != nil {
+		// NOTE: キャンセル由来のエラーはフロントエンドに通知しない。
+		// StopSimulation() 呼び出し元がキャンセルを把握済みのため。
+		if ctx.Err() != nil {
+			return
+		}
+		a.emitEvent(eventSimulationError, err.Error())
+		return
+	}
+
+	a.emitEvent(eventSimulationDone)
+}
+
+// StopSimulation は実行中のシミュレーションをキャンセルする。
+func (a *App) StopSimulation() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.cancel != nil {
+		a.cancel()
+	}
 }

--- a/app_test.go
+++ b/app_test.go
@@ -1,0 +1,293 @@
+//go:build gui
+
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/canpok1/yomite/core"
+)
+
+// mockProvider はテスト用のProviderモック。
+type mockProvider struct {
+	responses []core.SimulationResponse
+	errors    []error
+	callIdx   int
+	delay     time.Duration
+}
+
+func (m *mockProvider) Execute(req core.SimulationRequest) (core.SimulationResponse, error) {
+	if m.delay > 0 {
+		time.Sleep(m.delay)
+	}
+	idx := m.callIdx
+	m.callIdx++
+	if idx < len(m.errors) && m.errors[idx] != nil {
+		return core.SimulationResponse{}, m.errors[idx]
+	}
+	if idx < len(m.responses) {
+		return m.responses[idx], nil
+	}
+	return core.SimulationResponse{}, errors.New("no more mock responses")
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
+// eventRecord は発火されたイベントを記録する。
+type eventRecord struct {
+	Name string
+	Data []any
+}
+
+// newTestApp はテスト用のAppを生成する。providerを注入し、イベント発火を記録する。
+func newTestApp(provider core.Provider) (*App, *[]eventRecord) {
+	var mu sync.Mutex
+	var events []eventRecord
+
+	a := &App{}
+	a.ctx = context.Background()
+	a.providerFactory = func(cfg core.ProviderConfig) core.Provider {
+		return provider
+	}
+	a.emitEvent = func(eventName string, data ...any) {
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, eventRecord{Name: eventName, Data: data})
+	}
+	return a, &events
+}
+
+// setupTestEnv はテスト用の設定ファイルを配置し、環境を整える。
+func setupTestEnv(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	config := `{
+		"log": {"level": "info", "path": "` + dir + `/test.log"},
+		"default_provider": "test-provider",
+		"default_persona": "test-persona",
+		"providers": {
+			"test-provider": {
+				"type": "ollama",
+				"model": "test-model",
+				"origin": "http://localhost:11434"
+			}
+		},
+		"personas": {
+			"test-persona": {
+				"display_name": "テスト読者",
+				"system_prompt": "test prompt",
+				"memory_capacity": 100,
+				"max_steps": 10
+			}
+		}
+	}`
+	if err := os.WriteFile(dir+"/yomite.json", []byte(config), 0o644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+	t.Setenv("HOME", dir)
+	t.Chdir(dir)
+}
+
+// waitForSimulationDone はシミュレーションgoroutineの終了を待つ。
+func waitForSimulationDone(t *testing.T, app *App) {
+	t.Helper()
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for simulation to finish")
+			return
+		default:
+			app.mu.Lock()
+			done := app.cancel == nil
+			app.mu.Unlock()
+			if done {
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}
+
+func TestLoadDocument(t *testing.T) {
+	app := NewApp()
+
+	sentences := app.LoadDocument("文1。文2。文3。")
+
+	if len(sentences) != 3 {
+		t.Fatalf("expected 3 sentences, got %d", len(sentences))
+	}
+	if sentences[0].Content != "文1。" {
+		t.Errorf("expected first sentence '文1。', got %q", sentences[0].Content)
+	}
+	if sentences[2].Content != "文3。" {
+		t.Errorf("expected third sentence '文3。', got %q", sentences[2].Content)
+	}
+}
+
+func TestLoadDocument_Empty(t *testing.T) {
+	app := NewApp()
+
+	sentences := app.LoadDocument("")
+
+	if sentences != nil {
+		t.Errorf("expected nil for empty input, got %v", sentences)
+	}
+}
+
+func TestStartSimulation_EmitsStepsAndDone(t *testing.T) {
+	mock := &mockProvider{
+		responses: []core.SimulationResponse{
+			{CurrentIndex: 0, NextIndex: intPtr(1)},
+			{Memory: "mem0"},
+			{CurrentIndex: 1, NextIndex: nil},
+			{Memory: "mem1"},
+		},
+	}
+
+	setupTestEnv(t)
+	app, events := newTestApp(mock)
+
+	err := app.StartSimulation("文1。文2。", "test-provider", "test-persona")
+	if err != nil {
+		t.Fatalf("StartSimulation returned error: %v", err)
+	}
+
+	waitForSimulationDone(t, app)
+
+	var stepCount, doneCount int
+	for _, e := range *events {
+		switch e.Name {
+		case eventSimulationStep:
+			stepCount++
+		case eventSimulationDone:
+			doneCount++
+		case eventSimulationError:
+			t.Fatalf("unexpected simulation:error event: %v", e.Data)
+		}
+	}
+
+	if stepCount != 2 {
+		t.Errorf("expected 2 step events, got %d", stepCount)
+	}
+	if doneCount != 1 {
+		t.Errorf("expected 1 done event, got %d", doneCount)
+	}
+}
+
+func TestStartSimulation_ProviderError_EmitsError(t *testing.T) {
+	mock := &mockProvider{
+		errors: []error{errors.New("provider failure")},
+	}
+
+	setupTestEnv(t)
+	app, events := newTestApp(mock)
+
+	err := app.StartSimulation("テスト文。", "test-provider", "test-persona")
+	if err != nil {
+		t.Fatalf("StartSimulation returned error: %v", err)
+	}
+
+	waitForSimulationDone(t, app)
+
+	var errorCount int
+	for _, e := range *events {
+		if e.Name == eventSimulationError {
+			errorCount++
+		}
+	}
+
+	if errorCount != 1 {
+		t.Errorf("expected 1 error event, got %d", errorCount)
+	}
+}
+
+func TestStartSimulation_DuplicateCall(t *testing.T) {
+	var responses []core.SimulationResponse
+	for i := 0; i < 100; i++ {
+		responses = append(responses,
+			core.SimulationResponse{CurrentIndex: 0, NextIndex: intPtr(0)},
+			core.SimulationResponse{Memory: "mem"},
+		)
+	}
+	mock := &mockProvider{responses: responses, delay: 50 * time.Millisecond}
+
+	setupTestEnv(t)
+	app, _ := newTestApp(mock)
+
+	err := app.StartSimulation("テスト文。", "test-provider", "test-persona")
+	if err != nil {
+		t.Fatalf("first StartSimulation returned error: %v", err)
+	}
+
+	time.Sleep(30 * time.Millisecond)
+
+	err = app.StartSimulation("テスト文。", "test-provider", "test-persona")
+	if err == nil {
+		t.Fatal("expected error for duplicate StartSimulation, got nil")
+	}
+
+	app.StopSimulation()
+	waitForSimulationDone(t, app)
+}
+
+func TestStopSimulation_CancelsRunning(t *testing.T) {
+	var responses []core.SimulationResponse
+	for i := 0; i < 1000; i++ {
+		responses = append(responses,
+			core.SimulationResponse{CurrentIndex: 0, NextIndex: intPtr(0)},
+			core.SimulationResponse{Memory: "mem"},
+		)
+	}
+	mock := &mockProvider{responses: responses, delay: 10 * time.Millisecond}
+
+	setupTestEnv(t)
+	app, _ := newTestApp(mock)
+
+	err := app.StartSimulation("テスト文。", "test-provider", "test-persona")
+	if err != nil {
+		t.Fatalf("StartSimulation returned error: %v", err)
+	}
+
+	time.Sleep(30 * time.Millisecond)
+	app.StopSimulation()
+	waitForSimulationDone(t, app)
+
+	app.mu.Lock()
+	if app.cancel != nil {
+		t.Error("expected cancel to be nil after simulation stopped")
+	}
+	app.mu.Unlock()
+}
+
+func TestStopSimulation_NoOp(t *testing.T) {
+	app := NewApp()
+	app.StopSimulation()
+}
+
+func TestStartSimulation_InvalidProvider(t *testing.T) {
+	setupTestEnv(t)
+	app, _ := newTestApp(&mockProvider{})
+
+	err := app.StartSimulation("テスト。", "nonexistent", "test-persona")
+	if err == nil {
+		t.Fatal("expected error for invalid provider, got nil")
+	}
+}
+
+func TestStartSimulation_InvalidPersona(t *testing.T) {
+	setupTestEnv(t)
+	app, _ := newTestApp(&mockProvider{})
+
+	err := app.StartSimulation("テスト。", "test-provider", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for invalid persona, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- `app.go` にWailsバインディングメソッドを実装（LoadDocument, GetConfig, ListProviders, ListPersonas, StartSimulation, StopSimulation）
- `StartSimulation` はgoroutineで非同期実行し、Wails Events（`simulation:step`, `simulation:done`, `simulation:error`）で逐次通知
- `StopSimulation` でcontext cancellationによるシミュレーション中断をサポート
- `app_test.go` にモックProviderを使用したユニットテストを追加（8テストケース）

## Test plan

- [x] `go test -tags gui -v -count=1 .` — 全8テストがパス
- [x] `go test ./...` — 既存テストに影響なし
- [x] `gofmt` — フォーマット問題なし
- [x] `golangci-lint run --build-tags gui` — 0 issues

Closes #53

🤖 Generated with [Claude Code](https://claude.ai/code)