### PR TITLE
feat: シミュレーション結果の表示改善（背景色・連番・現在文ハイライト）

### DIFF
--- a/docs/draft/spec.md
+++ b/docs/draft/spec.md
@@ -119,7 +119,7 @@ type Sentence struct {
 ### ② SimulationStep (AI読者の思考ログ)
 ```go
 type SimulationStep struct {
-    Step        int    `json:"step"`
+    Step        int    `json:"step"`          // 1始まりの連番
     SentenceIdx int    `json:"current_index"` // 今読んだ文の位置
     TargetIdx   *int   `json:"next_index"`   // 次に読む文の位置 (nil = 読了)
     Note        *Note  `json:"note"`         // 思考の内容 (nil = 感想なし)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -76,7 +76,7 @@ function App() {
           )}
 
           <div className="flex-1 overflow-y-auto">
-            <SentenceList sentences={sentences} steps={simulation.steps} />
+            <SentenceList sentences={sentences} steps={simulation.steps} isRunning={simulation.status === "running"} />
           </div>
         </div>
       ) : (

--- a/frontend/src/components/SentenceList.tsx
+++ b/frontend/src/components/SentenceList.tsx
@@ -4,6 +4,7 @@ import type { NoteType, Sentence, SimulationStep } from "../types";
 interface SentenceListProps {
   sentences: Sentence[];
   steps?: SimulationStep[];
+  isRunning?: boolean;
 }
 
 type Direction = "done" | "forward" | "backward";
@@ -45,6 +46,26 @@ function groupStepsBySentence(steps: SimulationStep[]): Map<number, SimulationSt
   return map;
 }
 
+type SentenceNoteState = "confusion" | "resolved" | "none";
+
+function getSentenceNoteState(relatedSteps: SimulationStep[] | undefined): SentenceNoteState {
+  if (!relatedSteps) return "none";
+  let hasResolved = false;
+  for (const step of relatedSteps) {
+    // NOTE: 混乱は解決より読者体験上重大なため、見つかった時点で即確定する
+    if (step.note?.type === "CONFUSION") return "confusion";
+    if (step.note?.type === "RESOLVED") hasResolved = true;
+  }
+  if (hasResolved) return "resolved";
+  return "none";
+}
+
+const SENTENCE_BG_STYLES: Record<SentenceNoteState, string> = {
+  confusion: "bg-red-50 dark:bg-red-950 border-red-200 dark:border-red-800",
+  resolved: "bg-green-50 dark:bg-green-950 border-green-200 dark:border-green-800",
+  none: "bg-white dark:bg-gray-800 border-gray-200 dark:border-gray-700",
+};
+
 function StepRow({ step }: { step: SimulationStep }) {
   const dirStyle = DIRECTION_STYLES[getDirection(step)];
   return (
@@ -78,11 +99,24 @@ function StepRow({ step }: { step: SimulationStep }) {
   );
 }
 
-export function SentenceList({ sentences, steps = [] }: SentenceListProps) {
-  const stepsBySentence = useMemo(
-    () => groupStepsBySentence(steps),
-    [steps],
-  );
+export function SentenceList({ sentences, steps = [], isRunning = false }: SentenceListProps) {
+  const { stepsBySentence, noteStateBySentence } = useMemo(() => {
+    const stepsBySentence = groupStepsBySentence(steps);
+    const noteStateBySentence = new Map<number, SentenceNoteState>();
+    for (const [idx, relatedSteps] of stepsBySentence) {
+      noteStateBySentence.set(idx, getSentenceNoteState(relatedSteps));
+    }
+    return { stepsBySentence, noteStateBySentence };
+  }, [steps]);
+
+  // NOTE: isRunning=true のときのみ、最終ステップの next_index を「現在読書中の文」とみなす。
+  // 完了ステップ（next_index=null）は読書中扱いしない。
+  const currentSentenceIndex = useMemo(() => {
+    if (!isRunning || steps.length === 0) return null;
+    const lastStep = steps[steps.length - 1];
+    if (lastStep.next_index === null) return null;
+    return lastStep.next_index;
+  }, [steps, isRunning]);
 
   const bottomRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -95,16 +129,25 @@ export function SentenceList({ sentences, steps = [] }: SentenceListProps) {
     <ol className="flex flex-col gap-2">
       {sentences.map((sentence) => {
         const relatedSteps = stepsBySentence.get(sentence.index);
+        const noteState = noteStateBySentence.get(sentence.index) ?? "none";
+        const isCurrent = sentence.index === currentSentenceIndex;
         return (
           <li
             key={sentence.index}
-            className="flex gap-3 p-3 rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800"
+            className={`flex gap-3 p-3 rounded border ${SENTENCE_BG_STYLES[noteState]}${isCurrent ? " ring-2 ring-blue-400 dark:ring-blue-500" : ""}`}
           >
             <span className="shrink-0 w-8 h-8 flex items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900 text-blue-700 dark:text-blue-300 text-sm font-bold">
               {sentence.index + 1}
             </span>
             <div className="flex-1 min-w-0">
-              <p className="pt-1">{sentence.content}</p>
+              <div className="flex items-center gap-2 pt-1">
+                <span>{sentence.content}</span>
+                {isCurrent && (
+                  <span className="shrink-0 px-2 py-0.5 rounded text-xs font-semibold bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300 animate-pulse">
+                    読書中
+                  </span>
+                )}
+              </div>
               {relatedSteps && relatedSteps.length > 0 && (
                 <div className="mt-2 flex flex-col gap-1">
                   {relatedSteps.map((step) => (

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -107,8 +107,8 @@ func TestRun_Integration_TextOutput(t *testing.T) {
 	}
 
 	output := stdout.String()
-	if !strings.Contains(output, "[Step 0]") {
-		t.Errorf("expected Step 0 in output, got: %s", output)
+	if !strings.Contains(output, "[Step 1]") {
+		t.Errorf("expected Step 1 in output, got: %s", output)
 	}
 	if !strings.Contains(output, "Note[QUESTION]: これは何？") {
 		t.Errorf("expected QUESTION note, got: %s", output)
@@ -235,7 +235,7 @@ func TestRun_PersonaNotFound(t *testing.T) {
 
 func TestOutputStepJSON(t *testing.T) {
 	step := core.SimulationStep{
-		Step:        0,
+		Step:        1,
 		SentenceIdx: 0,
 		TargetIdx:   intPtr(1),
 		Note:        &core.Note{Type: core.NoteTypeQuestion, Content: "テスト疑問"},
@@ -297,19 +297,19 @@ func TestOutputStepText(t *testing.T) {
 
 	steps := []core.SimulationStep{
 		{
-			Step:        0,
+			Step:        1,
 			SentenceIdx: 0,
 			TargetIdx:   intPtr(1),
 			Note:        &core.Note{Type: core.NoteTypeQuestion, Content: "疑問"},
 		},
 		{
-			Step:        1,
+			Step:        2,
 			SentenceIdx: 1,
 			TargetIdx:   intPtr(0),
 			Note:        nil,
 		},
 		{
-			Step:        2,
+			Step:        3,
 			SentenceIdx: 0,
 			TargetIdx:   nil,
 			Note:        &core.Note{Type: core.NoteTypeResolved, Content: "解消"},
@@ -325,9 +325,9 @@ func TestOutputStepText(t *testing.T) {
 
 	output := stdout.String()
 
-	// Step 0: 先読み
-	if !strings.Contains(output, "[Step 0] 文0: 文1。") {
-		t.Errorf("expected step 0 header, got: %s", output)
+	// Step 1: 先読み
+	if !strings.Contains(output, "[Step 1] 文0: 文1。") {
+		t.Errorf("expected step 1 header, got: %s", output)
 	}
 	if !strings.Contains(output, "Note[QUESTION]: 疑問") {
 		t.Errorf("expected QUESTION note, got: %s", output)
@@ -358,7 +358,7 @@ func TestOutputStepText_Reread(t *testing.T) {
 	}
 
 	step := core.SimulationStep{
-		Step:        0,
+		Step:        1,
 		SentenceIdx: 0,
 		TargetIdx:   intPtr(0),
 	}

--- a/internal/core/simulator.go
+++ b/internal/core/simulator.go
@@ -29,7 +29,7 @@ func RunSimulation(doc Document, persona Persona, provider Provider, logger *slo
 	currentIdx := 0
 	completedSteps := 0
 
-	for step := 0; step < maxSteps; step++ {
+	for step := 1; step <= maxSteps; step++ {
 		// Phase 1: 感想生成（note + next_index）
 		noteReq := SimulationRequest{
 			Phase:           PhaseNote,

--- a/internal/core/simulator_test.go
+++ b/internal/core/simulator_test.go
@@ -70,17 +70,17 @@ func TestRunSimulation_NormalCompletion(t *testing.T) {
 	}
 	mock := &mockProvider{
 		responses: []SimulationResponse{
-			// Step 0: note
-			{CurrentIndex: 0, NextIndex: intPtr(1), Note: nil},
-			// Step 0: memory
-			{Memory: "文1を読んだ"},
 			// Step 1: note
-			{CurrentIndex: 1, NextIndex: intPtr(2), Note: &Note{Type: NoteTypeQuestion, Content: "なぜ？"}},
+			{CurrentIndex: 0, NextIndex: intPtr(1), Note: nil},
 			// Step 1: memory
-			{Memory: "文1と文2を読んだ"},
+			{Memory: "文1を読んだ"},
 			// Step 2: note
-			{CurrentIndex: 2, NextIndex: nil, Note: nil},
+			{CurrentIndex: 1, NextIndex: intPtr(2), Note: &Note{Type: NoteTypeQuestion, Content: "なぜ？"}},
 			// Step 2: memory
+			{Memory: "文1と文2を読んだ"},
+			// Step 3: note
+			{CurrentIndex: 2, NextIndex: nil, Note: nil},
+			// Step 3: memory
 			{Memory: "全部読んだ"},
 		},
 	}
@@ -96,31 +96,31 @@ func TestRunSimulation_NormalCompletion(t *testing.T) {
 		t.Fatalf("expected 3 steps, got %d", len(steps))
 	}
 
-	// Step 0
-	if steps[0].Step != 0 || steps[0].SentenceIdx != 0 {
-		t.Errorf("step 0: got Step=%d, SentenceIdx=%d", steps[0].Step, steps[0].SentenceIdx)
+	// Step 1
+	if steps[0].Step != 1 || steps[0].SentenceIdx != 0 {
+		t.Errorf("step 1: got Step=%d, SentenceIdx=%d", steps[0].Step, steps[0].SentenceIdx)
 	}
 	if steps[0].TargetIdx == nil || *steps[0].TargetIdx != 1 {
-		t.Errorf("step 0: expected TargetIdx=1, got %v", steps[0].TargetIdx)
+		t.Errorf("step 1: expected TargetIdx=1, got %v", steps[0].TargetIdx)
 	}
 	if steps[0].Note != nil {
-		t.Errorf("step 0: expected no note")
-	}
-
-	// Step 1
-	if steps[1].Step != 1 || steps[1].SentenceIdx != 1 {
-		t.Errorf("step 1: got Step=%d, SentenceIdx=%d", steps[1].Step, steps[1].SentenceIdx)
-	}
-	if steps[1].Note == nil || steps[1].Note.Type != NoteTypeQuestion {
-		t.Errorf("step 1: expected QUESTION note")
+		t.Errorf("step 1: expected no note")
 	}
 
 	// Step 2
-	if steps[2].Step != 2 || steps[2].SentenceIdx != 2 {
-		t.Errorf("step 2: got Step=%d, SentenceIdx=%d", steps[2].Step, steps[2].SentenceIdx)
+	if steps[1].Step != 2 || steps[1].SentenceIdx != 1 {
+		t.Errorf("step 2: got Step=%d, SentenceIdx=%d", steps[1].Step, steps[1].SentenceIdx)
+	}
+	if steps[1].Note == nil || steps[1].Note.Type != NoteTypeQuestion {
+		t.Errorf("step 2: expected QUESTION note")
+	}
+
+	// Step 3
+	if steps[2].Step != 3 || steps[2].SentenceIdx != 2 {
+		t.Errorf("step 3: got Step=%d, SentenceIdx=%d", steps[2].Step, steps[2].SentenceIdx)
 	}
 	if steps[2].TargetIdx != nil {
-		t.Errorf("step 2: expected nil TargetIdx for completion")
+		t.Errorf("step 3: expected nil TargetIdx for completion")
 	}
 }
 
@@ -141,16 +141,16 @@ func TestRunSimulation_MaxStepsTermination(t *testing.T) {
 	}
 	mock := &mockProvider{
 		responses: []SimulationResponse{
-			// Step 0: note, memory
+			// Step 1: note, memory
 			{CurrentIndex: 0, NextIndex: intPtr(1)},
 			{Memory: "m1"},
-			// Step 1: note, memory
+			// Step 2: note, memory
 			{CurrentIndex: 1, NextIndex: intPtr(0)},
 			{Memory: "m2"},
-			// Step 2: note, memory
+			// Step 3: note, memory
 			{CurrentIndex: 0, NextIndex: intPtr(1)},
 			{Memory: "m3"},
-			// Step 3 (won't reach): note, memory
+			// Step 4 (won't reach): note, memory
 			{CurrentIndex: 1, NextIndex: intPtr(0)},
 			{Memory: "m4"},
 		},
@@ -184,16 +184,16 @@ func TestRunSimulation_DefaultMaxSteps(t *testing.T) {
 	}
 	mock := &mockProvider{
 		responses: []SimulationResponse{
-			// Step 0: note, memory
-			{CurrentIndex: 0, NextIndex: intPtr(0)},
-			{Memory: "m1"},
 			// Step 1: note, memory
 			{CurrentIndex: 0, NextIndex: intPtr(0)},
-			{Memory: "m2"},
+			{Memory: "m1"},
 			// Step 2: note, memory
 			{CurrentIndex: 0, NextIndex: intPtr(0)},
+			{Memory: "m2"},
+			// Step 3: note, memory
+			{CurrentIndex: 0, NextIndex: intPtr(0)},
 			{Memory: "m3"},
-			// Step 3 (won't reach): note, memory
+			// Step 4 (won't reach): note, memory
 			{CurrentIndex: 0, NextIndex: intPtr(0)},
 			{Memory: "m4"},
 		},
@@ -228,13 +228,13 @@ func TestRunSimulation_ProviderErrorOnNote(t *testing.T) {
 	}
 	mock := &mockProvider{
 		responses: []SimulationResponse{
-			// Step 0: note, memory
+			// Step 1: note, memory
 			{CurrentIndex: 0, NextIndex: intPtr(1)},
 			{Memory: "m1"},
 		},
 		errors: []error{
 			nil, nil,
-			errors.New("LLM connection failed"), // Step 1 note fails
+			errors.New("LLM connection failed"), // Step 2 note fails
 		},
 	}
 
@@ -369,10 +369,10 @@ func TestRunSimulation_MemoryCapacityAppliedToNextStep(t *testing.T) {
 	}
 	mock := &mockProvider{
 		responses: []SimulationResponse{
-			// Step 0
+			// Step 1
 			{CurrentIndex: 0, NextIndex: intPtr(1)}, // note
 			{Memory: "あいうえお"},                       // memory (will be truncated to 3 chars)
-			// Step 1
+			// Step 2
 			{CurrentIndex: 1, NextIndex: nil}, // note
 			{Memory: "ok"},                    // memory
 		},
@@ -411,16 +411,16 @@ func TestRunSimulation_Backtracking(t *testing.T) {
 	}
 	mock := &mockProvider{
 		responses: []SimulationResponse{
-			// Step 0: note, memory
+			// Step 1: note, memory
 			{CurrentIndex: 0, NextIndex: intPtr(1)},
 			{Memory: "m1"},
-			// Step 1: note (backtrack), memory
+			// Step 2: note (backtrack), memory
 			{CurrentIndex: 1, NextIndex: intPtr(0)},
 			{Memory: "m2"},
-			// Step 2: note, memory
+			// Step 3: note, memory
 			{CurrentIndex: 0, NextIndex: intPtr(2)},
 			{Memory: "m3"},
-			// Step 3: note (done), memory
+			// Step 4: note (done), memory
 			{CurrentIndex: 2, NextIndex: nil},
 			{Memory: "m4"},
 		},
@@ -462,10 +462,10 @@ func TestRunSimulation_RequestFields(t *testing.T) {
 	}
 	mock := &mockProvider{
 		responses: []SimulationResponse{
-			// Step 0: note, memory
+			// Step 1: note, memory
 			{CurrentIndex: 0, NextIndex: intPtr(1)},
 			{Memory: "記憶1"},
-			// Step 1: note, memory
+			// Step 2: note, memory
 			{CurrentIndex: 1, NextIndex: nil},
 			{Memory: "記憶2"},
 		},
@@ -482,7 +482,7 @@ func TestRunSimulation_RequestFields(t *testing.T) {
 		t.Fatalf("expected 4 calls, got %d", len(mock.calls))
 	}
 
-	// Step 0 note request (calls[0])
+	// Step 1 note request (calls[0])
 	noteReq0 := mock.calls[0]
 	if noteReq0.Phase != PhaseNote {
 		t.Errorf("calls[0].Phase: got %d, want PhaseNote", noteReq0.Phase)
@@ -503,13 +503,13 @@ func TestRunSimulation_RequestFields(t *testing.T) {
 		t.Errorf("calls[0].Memory: got %q, want empty", noteReq0.Memory)
 	}
 
-	// Step 0 memory request (calls[1])
+	// Step 1 memory request (calls[1])
 	memReq0 := mock.calls[1]
 	if memReq0.Phase != PhaseMemory {
 		t.Errorf("calls[1].Phase: got %d, want PhaseMemory", memReq0.Phase)
 	}
 
-	// Step 1 note request (calls[2])
+	// Step 2 note request (calls[2])
 	noteReq1 := mock.calls[2]
 	if noteReq1.Phase != PhaseNote {
 		t.Errorf("calls[2].Phase: got %d, want PhaseNote", noteReq1.Phase)
@@ -639,10 +639,10 @@ func TestRunSimulation_LogOutput(t *testing.T) {
 	}
 	mock := &mockProvider{
 		responses: []SimulationResponse{
-			// Step 0: note, memory
+			// Step 1: note, memory
 			{CurrentIndex: 0, NextIndex: intPtr(1)},
 			{Memory: "m1"},
-			// Step 1: note, memory
+			// Step 2: note, memory
 			{CurrentIndex: 1, NextIndex: nil},
 			{Memory: "m2"},
 		},
@@ -719,10 +719,10 @@ func TestRunSimulation_CallbackCalledPerStep(t *testing.T) {
 	}
 	mock := &mockProvider{
 		responses: []SimulationResponse{
-			// Step 0: note, memory
+			// Step 1: note, memory
 			{CurrentIndex: 0, NextIndex: intPtr(1)},
 			{Memory: "m1"},
-			// Step 1: note, memory
+			// Step 2: note, memory
 			{CurrentIndex: 1, NextIndex: nil},
 			{Memory: "m2"},
 		},
@@ -741,8 +741,8 @@ func TestRunSimulation_CallbackCalledPerStep(t *testing.T) {
 	if len(callOrder) != 2 {
 		t.Fatalf("expected 2 callback calls, got %d", len(callOrder))
 	}
-	if callOrder[0] != 0 || callOrder[1] != 1 {
-		t.Errorf("expected callback order [0, 1], got %v", callOrder)
+	if callOrder[0] != 1 || callOrder[1] != 2 {
+		t.Errorf("expected callback order [1, 2], got %v", callOrder)
 	}
 }
 
@@ -763,7 +763,7 @@ func TestRunSimulation_CallbackError(t *testing.T) {
 	}
 	mock := &mockProvider{
 		responses: []SimulationResponse{
-			// Step 0: note, memory
+			// Step 1: note, memory
 			{CurrentIndex: 0, NextIndex: intPtr(1)},
 			{Memory: "m1"},
 		},
@@ -771,7 +771,7 @@ func TestRunSimulation_CallbackError(t *testing.T) {
 
 	callbackErr := errors.New("output failed")
 	onStep := func(s SimulationStep) error {
-		if s.Step == 0 {
+		if s.Step == 1 {
 			return callbackErr
 		}
 		return nil


### PR DESCRIPTION
## Summary

- 混乱(CONFUSION)ステップの文表示エリアに薄い赤、解決(RESOLVED)ステップに薄い緑の背景色を追加
- ステップ連番を0始まりから1始まりに変更（Go側ループ変更＋関連テスト全更新）
- シミュレーション進行中の現在読書文にリングハイライト＋「読書中」ラベルを表示
- noteState計算をuseMemoに統合し不要な再計算を防止

## 変更ファイル

- `frontend/src/components/SentenceList.tsx` — 背景色変更・現在文ハイライト・「読書中」ラベル
- `frontend/src/App.tsx` — isRunning propの追加
- `internal/core/simulator.go` — ステップ連番の開始値変更（0→1）
- `internal/core/simulator_test.go` — テストのアサーション・コメント更新
- `internal/cli/run_test.go` — テストのアサーション更新
- `docs/draft/spec.md` — SimulationStep.Stepに「1始まりの連番」コメント追加

## Test plan

- [x] Go テスト全パス確認（`go test ./internal/core/ ./internal/cli/`）
- [x] TypeScript 型チェック全パス確認（`npx tsc --noEmit`）
- [x] gofmt / golangci-lint チェック通過
- [ ] GUI上で混乱・解決の背景色が正しく表示されることを確認
- [ ] GUI上でシミュレーション進行中に「読書中」ラベルが表示されることを確認
- [ ] CLI出力で Step 1 から開始されることを確認

Closes #75

🤖 Generated with [Claude Code](https://claude.ai/code)