### PR TITLE
feat: 付箋（StickyNote）コンポーネントによるNote色分け表示

### DIFF
--- a/frontend/src/components/SentenceList.tsx
+++ b/frontend/src/components/SentenceList.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
-import type { NoteType, Sentence, SimulationStep } from "../types";
+import type { Note, NoteType, Sentence, SimulationStep } from "../types";
+import { NOTE_LABELS } from "../constants/noteStyles";
+import { StickyNoteStack } from "./StickyNote";
 
 interface SentenceListProps {
   sentences: Sentence[];
@@ -24,10 +26,12 @@ const DIRECTION_STYLES: Record<Direction, { label: string; color: string }> = {
   },
 };
 
-const NOTE_TYPE_STYLES: Record<NoteType, { label: string; color: string }> = {
-  QUESTION: { label: "疑問", color: "text-purple-600 dark:text-purple-400" },
-  RESOLVED: { label: "解決", color: "text-green-600 dark:text-green-400" },
-  CONFUSION: { label: "混乱", color: "text-red-600 dark:text-red-400" },
+// NOTE: StepRowのバッジ色はStickyNoteの背景色系統と意図的に異ならせている。
+// StickyNoteは付箋カードとして背景色+左ボーダーで表現し、StepRowバッジはテキスト色のみで簡潔に表示する。
+const NOTE_TYPE_COLORS: Record<NoteType, string> = {
+  QUESTION: "text-purple-600 dark:text-purple-400",
+  RESOLVED: "text-green-600 dark:text-green-400",
+  CONFUSION: "text-red-600 dark:text-red-400",
 };
 
 function getDirection(step: SimulationStep): Direction {
@@ -84,15 +88,10 @@ function StepRow({ step }: { step: SimulationStep }) {
         </span>
       )}
       {step.note && (
-        <span className="text-xs">
-          <span
-            className={`font-semibold ${NOTE_TYPE_STYLES[step.note.type].color}`}
-          >
-            [{NOTE_TYPE_STYLES[step.note.type].label}]
-          </span>{" "}
-          <span className="text-gray-600 dark:text-gray-400">
-            {step.note.content}
-          </span>
+        <span
+          className={`text-xs font-semibold ${NOTE_TYPE_COLORS[step.note.type]}`}
+        >
+          [{NOTE_LABELS[step.note.type]}]
         </span>
       )}
     </div>
@@ -100,13 +99,23 @@ function StepRow({ step }: { step: SimulationStep }) {
 }
 
 export function SentenceList({ sentences, steps = [], isRunning = false }: SentenceListProps) {
-  const { stepsBySentence, noteStateBySentence } = useMemo(() => {
+  const { stepsBySentence, noteStateBySentence, notesBySentence } = useMemo(() => {
     const stepsBySentence = groupStepsBySentence(steps);
     const noteStateBySentence = new Map<number, SentenceNoteState>();
+    const notesBySentence = new Map<number, { note: Note; stepNumber: number }[]>();
     for (const [idx, relatedSteps] of stepsBySentence) {
       noteStateBySentence.set(idx, getSentenceNoteState(relatedSteps));
+      const notes: { note: Note; stepNumber: number }[] = [];
+      for (const step of relatedSteps) {
+        if (step.note) {
+          notes.push({ note: step.note, stepNumber: step.step });
+        }
+      }
+      if (notes.length > 0) {
+        notesBySentence.set(idx, notes);
+      }
     }
-    return { stepsBySentence, noteStateBySentence };
+    return { stepsBySentence, noteStateBySentence, notesBySentence };
   }, [steps]);
 
   // NOTE: isRunning=true のときのみ、最終ステップの next_index を「現在読書中の文」とみなす。
@@ -148,7 +157,8 @@ export function SentenceList({ sentences, steps = [], isRunning = false }: Sente
                   </span>
                 )}
               </div>
-              {relatedSteps && relatedSteps.length > 0 && (
+              <StickyNoteStack notes={notesBySentence.get(sentence.index) ?? []} />
+              {relatedSteps && (
                 <div className="mt-2 flex flex-col gap-1">
                   {relatedSteps.map((step) => (
                     <StepRow key={step.step} step={step} />

--- a/frontend/src/components/StickyNote.tsx
+++ b/frontend/src/components/StickyNote.tsx
@@ -1,0 +1,63 @@
+import type { Note, NoteType } from "../types";
+import { NOTE_LABELS } from "../constants/noteStyles";
+
+const NOTE_STYLES: Record<
+  NoteType,
+  { bg: string; border: string; text: string }
+> = {
+  QUESTION: {
+    bg: "bg-yellow-100 dark:bg-yellow-900",
+    border: "border-yellow-400 dark:border-yellow-600",
+    text: "text-yellow-800 dark:text-yellow-200",
+  },
+  CONFUSION: {
+    bg: "bg-red-100 dark:bg-red-900",
+    border: "border-red-400 dark:border-red-600",
+    text: "text-red-800 dark:text-red-200",
+  },
+  RESOLVED: {
+    bg: "bg-green-100 dark:bg-green-900",
+    border: "border-green-400 dark:border-green-600",
+    text: "text-green-800 dark:text-green-200",
+  },
+};
+
+interface StickyNoteProps {
+  note: Note;
+  stepNumber: number;
+}
+
+export function StickyNote({ note, stepNumber }: StickyNoteProps) {
+  const style = NOTE_STYLES[note.type];
+  const label = NOTE_LABELS[note.type];
+  return (
+    <div
+      className={`${style.bg} ${style.border} border-l-4 rounded-r px-3 py-1.5 text-sm`}
+    >
+      <span className={`font-semibold ${style.text}`}>
+        [{label}]
+      </span>{" "}
+      <span className="text-gray-700 dark:text-gray-300">
+        {note.content}
+      </span>
+      <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">
+        ステップ {stepNumber}
+      </span>
+    </div>
+  );
+}
+
+interface StickyNoteStackProps {
+  notes: { note: Note; stepNumber: number }[];
+}
+
+export function StickyNoteStack({ notes }: StickyNoteStackProps) {
+  if (notes.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-1 mt-2">
+      {notes.map(({ note, stepNumber }) => (
+        <StickyNote key={stepNumber} note={note} stepNumber={stepNumber} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/constants/noteStyles.ts
+++ b/frontend/src/constants/noteStyles.ts
@@ -1,0 +1,7 @@
+import type { NoteType } from "../types";
+
+export const NOTE_LABELS: Record<NoteType, string> = {
+  QUESTION: "疑問",
+  CONFUSION: "混乱",
+  RESOLVED: "解消",
+};


### PR DESCRIPTION
## Summary

- StickyNoteコンポーネントを新規作成し、シミュレーション結果のNoteを付箋カード形式で各文に表示
- NoteTypeに応じた色分け表示: QUESTION=黄、CONFUSION=赤、RESOLVED=緑
- SentenceListとの統合: 同一文への複数Noteをスタック表示、useMemoによるメモ化で効率的なレンダリング
- NOTE_LABELSを共通定数として分離し、StickyNote・SentenceList間でラベル定義を一元化
- StepRowのバッジ色とStickyNoteの付箋色の意図的な差異をNOTE:コメントで明示

## 対象ファイル

- `frontend/src/components/StickyNote.tsx` — 新規: 付箋コンポーネント
- `frontend/src/components/SentenceList.tsx` — 変更: Note統合表示
- `frontend/src/constants/noteStyles.ts` — 新規: 共通ラベル定数

## Test plan

- [ ] シミュレーション実行後、Noteが正しい文の横に付箋として表示される
- [ ] 色分けが仕様通り: QUESTION=黄、CONFUSION=赤、RESOLVED=緑
- [ ] 同一文への複数Noteがスタック表示される
- [ ] ストリーミング中にリアルタイムでNoteが追加表示される
- [ ] TypeScript型チェック通過（`tsc --noEmit`）
- [ ] ESLintチェック通過（`npm run lint`）

Closes #57

🤖 Generated with [Claude Code](https://claude.ai/code)