### PR TITLE
fix: シミュレーション中のスクロール先を読書中の文に変更する

### DIFF
--- a/frontend/src/components/SentenceList.tsx
+++ b/frontend/src/components/SentenceList.tsx
@@ -127,12 +127,13 @@ export function SentenceList({ sentences, steps = [], isRunning = false }: Sente
     return lastStep.next_index;
   }, [steps, isRunning]);
 
-  const bottomRef = useRef<HTMLDivElement>(null);
+  const currentSentenceRef = useRef<HTMLLIElement>(null);
+  // NOTE: 依存配列はcurrentSentenceIndexのみ。同一文に留まるステップ追加時の再スクロールは不要なため、steps.lengthは含めない。
   useEffect(() => {
-    if (steps.length > 0) {
-      bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    if (currentSentenceIndex !== null) {
+      currentSentenceRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
     }
-  }, [steps.length]);
+  }, [currentSentenceIndex]);
 
   return (
     <ol className="flex flex-col gap-2">
@@ -143,6 +144,7 @@ export function SentenceList({ sentences, steps = [], isRunning = false }: Sente
         return (
           <li
             key={sentence.index}
+            ref={isCurrent ? currentSentenceRef : null}
             data-sentence-index={sentence.index}
             className={`flex gap-3 p-3 rounded border ${SENTENCE_BG_STYLES[noteState]}${isCurrent ? " ring-2 ring-blue-400 dark:ring-blue-500" : ""}`}
           >
@@ -170,7 +172,6 @@ export function SentenceList({ sentences, steps = [], isRunning = false }: Sente
           </li>
         );
       })}
-      <div ref={bottomRef} />
     </ol>
   );
 }


### PR DESCRIPTION
## Summary

- シミュレーション中のスクロール先を `bottomRef`（リスト最下部）から `currentSentenceIndex` に対応する `<li>` 要素に変更
- シミュレーション完了時（`currentSentenceIndex === null`）はスクロールをスキップ
- 番兵要素 `<div ref={bottomRef} />` を削除し、読書中の文に直接 `ref` を割り当て

Closes #81

## 変更内容

- `bottomRef` → `currentSentenceRef` に置き換え
- `useEffect` の依存配列を `steps.length` → `currentSentenceIndex` に変更
- `scrollIntoView` に `block: "center"` を追加し、読書中の文が画面中央に表示されるよう改善

## Test plan

- [ ] シミュレーション実行中に、読書中の文（「読書中」バッジ付き）が画面中央にスクロールされることを確認
- [ ] ステップ進行ごとに、新しい読書中の文にスムーズスクロールされることを確認
- [ ] シミュレーション完了時（全文読了後）にスクロールが発生しないことを確認
- [ ] 手動スクロール後、次のステップで読書中の文に再スクロールされることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)