### PR TITLE
fix: SplitSentences() の空入力時の返却値を nil から空スライスに統一

### DIFF
--- a/internal/core/document.go
+++ b/internal/core/document.go
@@ -14,7 +14,7 @@ import (
 //  5. 空白のみ・空文字の文はフィルタリングして除外する。
 func (d *Document) SplitSentences() []Sentence {
 	if d.RawText == "" {
-		return nil
+		return []Sentence{}
 	}
 
 	// まず段落区切り（空行）で分割
@@ -27,7 +27,8 @@ func (d *Document) SplitSentences() []Sentence {
 	}
 
 	// 空文除外してSentenceスライスを構築
-	var sentences []Sentence
+	// NOTE: nilではなく空スライスを返すことで、JSON出力が"null"ではなく"[]"になることを保証する。
+	sentences := make([]Sentence, 0)
 	for _, part := range rawParts {
 		trimmed := strings.TrimSpace(part)
 		if trimmed == "" {

--- a/internal/core/document_test.go
+++ b/internal/core/document_test.go
@@ -11,6 +11,9 @@ func TestSplitSentences_EmptyString(t *testing.T) {
 	doc := Document{RawText: ""}
 	got := doc.SplitSentences()
 
+	if got == nil {
+		t.Error("expected non-nil empty slice, got nil")
+	}
 	if len(got) != 0 {
 		t.Errorf("expected empty slice, got %v", got)
 	}

--- a/internal/gui/app_test.go
+++ b/internal/gui/app_test.go
@@ -135,8 +135,11 @@ func TestLoadDocument_Empty(t *testing.T) {
 
 	sentences := app.LoadDocument("")
 
-	if sentences != nil {
-		t.Errorf("expected nil for empty input, got %v", sentences)
+	if sentences == nil {
+		t.Error("expected non-nil empty slice, got nil")
+	}
+	if len(sentences) != 0 {
+		t.Errorf("expected empty slice, got %v", sentences)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `SplitSentences()` が空入力時に `nil` ではなく `[]Sentence{}` を返すように修正
- 分割結果が0件のケース（スペースのみ等）でも non-nil を保証するよう `make([]Sentence, 0)` で初期化
- テストに non-nil 検証を追加（`document_test.go`, `app_test.go`）

Closes #16

## Test plan

- [x] `TestSplitSentences_EmptyString` が non-nil 空スライスを検証
- [x] `TestLoadDocument_Empty` が non-nil 空スライスを検証
- [x] 既存テスト全件パス
- [x] `golangci-lint` / `gofmt` チェック通過

🤖 Generated with [Claude Code](https://claude.ai/code)