### PR TITLE
fix: シミュレーション開始時に最初の文に「読書中」ラベルが付与されるよう修正

### DIFF
--- a/frontend/src/components/SentenceList.tsx
+++ b/frontend/src/components/SentenceList.tsx
@@ -118,13 +118,13 @@ export function SentenceList({ sentences, steps = [], isRunning = false }: Sente
     return { stepsBySentence, noteStateBySentence, notesBySentence };
   }, [steps]);
 
-  // NOTE: isRunning=true のときのみ、最終ステップの next_index を「現在読書中の文」とみなす。
-  // 完了ステップ（next_index=null）は読書中扱いしない。
+  // NOTE: next_index だと常に1つ先の文にラベルが付いてしまうため、current_index を使用する。
+  // ステップ未受信時は最初の文（index=0）を読書中とみなす。
   const currentSentenceIndex = useMemo(() => {
-    if (!isRunning || steps.length === 0) return null;
+    if (!isRunning) return null;
+    if (steps.length === 0) return 0;
     const lastStep = steps[steps.length - 1];
-    if (lastStep.next_index === null) return null;
-    return lastStep.next_index;
+    return lastStep.current_index;
   }, [steps, isRunning]);
 
   const currentSentenceRef = useRef<HTMLLIElement>(null);


### PR DESCRIPTION
## 概要

- シミュレーション開始直後（ステップ未受信時）に最初の文（index=0）に「読書中」ラベルを付与するよう修正
- ステップ受信後は `next_index`（次に進む文）ではなく `current_index`（現在読んでいる文）を使用するよう変更

## 修正内容

`SentenceList.tsx` の `currentSentenceIndex` 算出ロジックを修正:

1. `steps.length === 0` のとき `null` → `0` を返すように変更（開始直後に最初の文をハイライト）
2. `lastStep.next_index` → `lastStep.current_index` に変更（現在読んでいる文を正しくハイライト）

Closes #90

## テスト計画

- [ ] シミュレーション開始直後に最初の文（index=0）に「読書中」ラベルが表示されること
- [ ] ステップ受信後、現在読んでいる文に「読書中」ラベルが表示されること（1つ先の文ではないこと）
- [ ] シミュレーション停止後、「読書中」ラベルが消えること

🤖 Generated with [Claude Code](https://claude.ai/code)