### PR TITLE
feat: シミュレーション結果画面にステップごと・合計の処理時間を表示する

### DIFF
--- a/docs/draft/spec.md
+++ b/docs/draft/spec.md
@@ -124,6 +124,7 @@ type SimulationStep struct {
     TargetIdx   *int   `json:"next_index"`   // 次に読む文の位置 (nil = 読了)
     Note        *Note  `json:"note"`         // 思考の内容 (nil = 感想なし)
     Memory      string `json:"memory"`       // このステップ時点での記憶内容
+    DurationMs  int64  `json:"duration_ms"`  // ステップの処理時間（ミリ秒）
 }
 
 type Note struct {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Editor } from "./components/Editor";
 import { SentenceList } from "./components/SentenceList";
 import { GazeArrows } from "./components/GazeArrows";
@@ -33,6 +33,11 @@ function App() {
   const sentenceListRef = useRef<HTMLDivElement>(null);
 
   const isResultView = sentences.length > 0 && simulation.status !== "idle";
+
+  const totalDurationMs = useMemo(
+    () => simulation.steps.reduce((sum, step) => sum + step.duration_ms, 0),
+    [simulation.steps],
+  );
 
   async function handleStart(text: string, providerID: string, personaID: string) {
     const result = await LoadDocument(text);
@@ -85,6 +90,11 @@ function App() {
                 className={`text-xs px-2 py-0.5 rounded ${STATUS_BADGE[simulation.status]!.className}`}
               >
                 {STATUS_BADGE[simulation.status]!.label}
+              </span>
+            )}
+            {simulation.status === "completed" && totalDurationMs > 0 && (
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                合計 {(totalDurationMs / 1000).toFixed(1)}s
               </span>
             )}
             {simulation.status === "running" && (

--- a/frontend/src/components/SentenceList.tsx
+++ b/frontend/src/components/SentenceList.tsx
@@ -96,6 +96,11 @@ function StepRow({ step }: { step: SimulationStep }) {
             [{NOTE_LABELS[step.note.type]}]
           </span>
         )}
+        {step.duration_ms > 0 && (
+          <span className="text-xs text-gray-400 dark:text-gray-500">
+            {(step.duration_ms / 1000).toFixed(1)}s
+          </span>
+        )}
         {step.memory && (
           <button
             type="button"

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -12,6 +12,7 @@ export interface SimulationStep {
   next_index: number | null;
   note: Note | null;
   memory: string;
+  duration_ms: number;
 }
 
 export interface Note {

--- a/internal/core/simulator.go
+++ b/internal/core/simulator.go
@@ -3,6 +3,7 @@ package core
 import (
 	"fmt"
 	"log/slog"
+	"time"
 )
 
 // RunSimulation はドキュメントに対してAI読者シミュレーションを実行する。
@@ -30,6 +31,8 @@ func RunSimulation(doc Document, persona Persona, provider Provider, logger *slo
 	completedSteps := 0
 
 	for step := 1; step <= maxSteps; step++ {
+		stepStart := time.Now()
+
 		// Phase 1: 感想生成（note + next_index）
 		noteReq := SimulationRequest{
 			Phase:           PhaseNote,
@@ -95,6 +98,7 @@ func RunSimulation(doc Document, persona Persona, provider Provider, logger *slo
 			TargetIdx:   noteResp.NextIndex,
 			Note:        noteResp.Note,
 			Memory:      memory,
+			DurationMs:  time.Since(stepStart).Milliseconds(),
 		}
 		if err := onStep(s); err != nil {
 			return fmt.Errorf("step %d: callback error: %w", step, err)
@@ -105,6 +109,7 @@ func RunSimulation(doc Document, persona Persona, provider Provider, logger *slo
 			"step", step,
 			"current_index", currentIdx,
 			"next_index", noteResp.NextIndex,
+			"duration_ms", s.DurationMs,
 		)
 
 		if !hasNext {

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -29,6 +29,7 @@ type SimulationStep struct {
 	TargetIdx   *int   `json:"next_index"`
 	Note        *Note  `json:"note"`
 	Memory      string `json:"memory"`
+	DurationMs  int64  `json:"duration_ms"`
 }
 
 // Note はシミュレーション中の読者の感想を表す。


### PR DESCRIPTION
## Summary

- バックエンド（Go）: `SimulationStep` に `DurationMs` フィールドを追加し、各ステップのPhase1+Phase2の処理時間をミリ秒単位で計測
- フロントエンド（React）: ステップ行に秒単位の処理時間を表示、シミュレーション完了時に合計時間をヘッダーに表示
- 仕様書（spec.md）: `DurationMs` フィールドの記載を追加

Closes #95

## Test plan

- [ ] シミュレーション実行後、各ステップ行に処理時間（例: `1.2s`）が表示されることを確認
- [ ] シミュレーション完了後、ヘッダー付近に合計処理時間が表示されることを確認
- [ ] `go test ./internal/core/` が全件パスすることを確認
- [ ] `npx tsc --noEmit` が型エラーなくパスすることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)